### PR TITLE
chore: GitHub Actions artifact actions v4로 업그레이드 (#14)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -111,7 +111,7 @@ jobs:
         run: ./gradlew build -x test --no-daemon
       
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: fourtune-jar
           path: fourtune/build/libs/*.jar
@@ -128,7 +128,7 @@ jobs:
         uses: actions/checkout@v4
       
       - name: Download build artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: fourtune-jar
           path: fourtune/build/libs


### PR DESCRIPTION
- actions/upload-artifact@v3 → v4
- actions/download-artifact@v3 → v4
- deprecated 버전 경고 해결

## 📌 개요
- 작업의 목적 및 배경을 간단히 설명해주세요.

## 👩‍💻 작업 사항
- [ ] 핵심 변경 사항을 체크리스트로 작성해주세요.
- [ ] 

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
