### PR TITLE
chore: /actuator/health 엔드포인트 접근 허용 (#38)

### DIFF
--- a/fourtune/src/main/java/com/fourtune/auction/global/config/SecurityConfig.java
+++ b/fourtune/src/main/java/com/fourtune/auction/global/config/SecurityConfig.java
@@ -34,6 +34,7 @@ public class SecurityConfig {
                         .requestMatchers("/", "/index.html" /*조회 검색 추가*/).permitAll()
                         .requestMatchers("/css/**", "/js/**", "/images/**", "/favicon.ico").permitAll()
                         .requestMatchers("/error").permitAll()
+                        .requestMatchers("/actuator/health").permitAll()
 
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
 


### PR DESCRIPTION
## 📌 개요
- /actuator/health 엔드포인트 외부 접근 허용

## 👩‍💻 작업 사항
- [x] Spring Security 설정에서 /actuator/health 엔드포인트를 permitAll()로 허용
- [x] Actuator health 엔드포인트 정상 응답 여부 확인
- [x] 인증이 필요한 다른 API 엔드포인트에 영향 없는지 검증

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #38
