### PR TITLE
feat: BaseManualIdAndTime 도입 (#47)

### DIFF
--- a/fourtune/src/main/java/com/fourtune/auction/global/common/BaseManualIdAndTime.java
+++ b/fourtune/src/main/java/com/fourtune/auction/global/common/BaseManualIdAndTime.java
@@ -1,0 +1,31 @@
+package com.fourtune.auction.global.common;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor
+public abstract class BaseManualIdAndTime {
+    @Id
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    public BaseManualIdAndTime(Long id) {
+        this.id = id;
+    }
+}


### PR DESCRIPTION
## 📌 개요
- 수동 ID 엔티티 공통 베이스를 제공하는 BaseManualIdAndTime 추가

## 👩‍💻 작업 사항
- [x] BaseManualIdAndTime 도입

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- #47
