### PR TITLE
fix: Vercel 지원을 위한 CORS 설정을 allowedOriginPatterns로 변경

### DIFF
--- a/fourtune/src/main/java/com/fourtune/auction/global/config/WebConfig.java
+++ b/fourtune/src/main/java/com/fourtune/auction/global/config/WebConfig.java
@@ -10,13 +10,12 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins(
+                .allowedOriginPatterns(
                         "http://localhost:5173",
                         "http://localhost:3000",
                         "https://fourtune.store",
                         "https://www.fourtune.store",
-                        "https://*.vercel.app"
-                )
+                        "https://*.vercel.app")
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true)


### PR DESCRIPTION
## 📌 개요
- Vercel 지원을 위한 CORS 설정을 allowedOriginPatterns로 변경

## 👩‍💻 작업 사항
- [x] allowedOrigin을 allowedOriginPatterns로 변경

## ✅ 테스트 결과
- .

## 🔗 관련 이슈
- close #134
