### PR TITLE
feat: 낙찰 미결제 유찰 처리 및 입찰가 역전 방지

### DIFF
--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/event/AuctionEventListener.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/event/AuctionEventListener.java
@@ -146,7 +146,7 @@ public class AuctionEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     public void handlePaymentFailed(PaymentFailedEvent event) {
         String orderId = event.getOrder() != null 
-                ? String.valueOf(event.getOrder().getOrderId()) 
+                ? String.valueOf(event.getOrder().getOrderNo()) 
                 : "unknown";
         String resultCode = event.getResultCode();
         String message = event.getMsg();

--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/BidPlaceUseCase.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/BidPlaceUseCase.java
@@ -148,13 +148,20 @@ public class BidPlaceUseCase {
             throw new BusinessException(ErrorCode.BID_SELF_AUCTION);
         }
         
-        // 4. 이미 최고 입찰자인지 확인
+        // 4. 가격 역전 방지: 입찰가가 즉시구매가 이상이면 차단 (즉시구매 유도)
+        if (Boolean.TRUE.equals(auctionItem.getBuyNowEnabled()) && auctionItem.getBuyNowPrice() != null) {
+            if (bidAmount.compareTo(auctionItem.getBuyNowPrice()) >= 0) {
+                throw new BusinessException(ErrorCode.BID_PRICE_HIGHER_THAN_BUY_NOW);
+            }
+        }
+        
+        // 5. 이미 최고 입찰자인지 확인
         Optional<Bid> highestBid = bidSupport.findHighestBid(auctionItem.getId());
         if (highestBid.isPresent() && highestBid.get().getBidderId().equals(bidderId)) {
             throw new BusinessException(ErrorCode.BID_ALREADY_HIGHEST);
         }
         
-        // 5. 입찰 금액이 현재가 + 입찰단위 이상인지
+        // 6. 입찰 금액이 현재가 + 입찰단위 이상인지
         BigDecimal currentPrice = auctionItem.getCurrentPrice() != null 
                 ? auctionItem.getCurrentPrice() 
                 : auctionItem.getStartPrice();

--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/domain/constant/AuctionPolicy.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/domain/constant/AuctionPolicy.java
@@ -1,6 +1,7 @@
 package com.fourtune.auction.boundedContext.auction.domain.constant;
 
 import lombok.Getter;
+import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
 
@@ -9,8 +10,9 @@ import java.math.BigDecimal;
 @Component
 @ConfigurationProperties(prefix = "auction")
 @Getter
+@Setter
 public class AuctionPolicy {
-    
+
     private Integer bidUnit = 1000;
     private Integer autoExtendMinutes = 3;
     private Integer autoExtendThresholdMinutes = 5;

--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/domain/constant/AuctionStatus.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/domain/constant/AuctionStatus.java
@@ -11,6 +11,7 @@ public enum AuctionStatus {
     ENDED("종료"),
     SOLD("낙찰 완료"),
     SOLD_BY_BUY_NOW("즉시구매 완료"),
+    FAIL("유찰"),           // 낙찰자 미결제 등으로 거래 미성사
     CANCELLED("취소");
 
     private final String description;

--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/domain/entity/AuctionItem.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/domain/entity/AuctionItem.java
@@ -315,6 +315,17 @@ public class AuctionItem extends BaseTimeEntity {
     }
     
     /**
+     * 낙찰자 미결제 시 유찰 처리 (SOLD → FAIL)
+     * 24시간 내 결제하지 않아 주문이 취소된 경우 호출
+     */
+    public void fail() {
+        if (this.status != AuctionStatus.SOLD) {
+            throw new BusinessException(ErrorCode.AUCTION_NOT_MODIFIABLE);
+        }
+        this.status = AuctionStatus.FAIL;
+    }
+
+    /**
      * 즉시구매 취소 시 경매 복구 (SOLD_BY_BUY_NOW → ACTIVE)
      * 주문 취소/만료로 결제가 이뤄지지 않았을 때만 호출
      */

--- a/fourtune/src/main/java/com/fourtune/auction/global/error/ErrorCode.java
+++ b/fourtune/src/main/java/com/fourtune/auction/global/error/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     BID_ALREADY_HIGHEST(400, "B006", "이미 최고 입찰자입니다."),
     BID_CANCELLED_NOT_ALLOWED(400, "B007", "취소할 수 없는 입찰입니다."),
     BID_LOCK_FAILED(500, "B008", "입찰 처리 중 오류가 발생했습니다."),
+    BID_PRICE_HIGHER_THAN_BUY_NOW(400, "B009", "입찰 금액이 즉시 구매가보다 높습니다. 즉시 구매를 이용해주세요."),
     
     //Order(주문 관련)
     ORDER_NOT_FOUND(404, "O001", "존재하지 않는 주문입니다."),


### PR DESCRIPTION
## 📌 개요
- 목적: 낙찰 후 미결제 시 경매 상태를 유찰(FAIL)로 처리하고, 입찰가가 즉시구매가 이상인 경우를 차단해 경매 로직을 보완
- 배경: 낙찰 미결제 시 경매가 SOLD로 남는 문제와, 입찰가 ≥ 즉시구매가 허용으로 인한 가격 역전 문제를 해결

## 👩‍💻 작업 사항
- [x] 낙찰 미결제 시 경매 상태 SOLD → FAIL(유찰) 처리
AuctionStatus에 FAIL enum 추가
AuctionItem.fail() 메서드 추가
OrderCompleteUseCase.cancelOrderInternal에서 SOLD 분기 시 auction.fail() 호출 및 저장
- [x] 입찰가 ≥ 즉시구매가일 때 입찰 차단 (가격 역전 방지)
BidPlaceUseCase.validateBidPlaceable에 buyNowPrice 검증 추가
ErrorCode.BID_PRICE_HIGHER_THAN_BUY_NOW(B009) 추가
- [x] 결제 실패 이벤트 처리 시 orderId → orderNo 사용
AuctionEventListener.handlePaymentFailed에서 getOrderNo() 사용
- [x] AuctionPolicy에 @Setter 추가
application.yml의 auction.payment-deadline-days 등 ConfigurationProperties 바인딩 가능하도록 수정

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
