### PR TITLE
test: 테스트 실패 방지를 위해 Elasticsearch 컨테이너 시작 대기 시간을 확장

### DIFF
--- a/fourtune/src/test/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/ElasticsearchAuctionItemSearchEngineIntegrationTest.java
+++ b/fourtune/src/test/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/ElasticsearchAuctionItemSearchEngineIntegrationTest.java
@@ -22,6 +22,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.math.BigDecimal;
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -42,7 +43,8 @@ class ElasticsearchAuctionItemSearchEngineIntegrationTest {
             "docker.elastic.co/elasticsearch/elasticsearch:9.2.3")
             .withEnv("xpack.security.enabled", "false")
             .withEnv("discovery.type", "single-node")
-            .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m");
+            .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+            .withStartupTimeout(Duration.ofMinutes(5)); // 타임아웃 시간을 5분으로 연장
 
     @DynamicPropertySource
     static void setProperties(DynamicPropertyRegistry registry) {


### PR DESCRIPTION
## 📌 개요
- 테스트 실패 방지를 위해 Elasticsearch 컨테이너 시작 대기 시간을 확장

## 👩‍💻 작업 사항
- [x] ElasticSearch 검색 엔진 통합 테스트의 컨테이너 시작 대기 시간을 5분으로 확장
- [x] 테스트 성공 확인

## ✅ 테스트 결과

## 🔗 관련 이슈
- close #216
