### PR TITLE
refactor: 검색 로그 엔티티 컬럼명 수정

### DIFF
--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/search/domain/SearchLog.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/search/domain/SearchLog.java
@@ -18,8 +18,8 @@ import java.util.List;
 @Getter
 @Table(name = "search_log", indexes = {
         @Index(name = "idx_search_log_keyword", columnList = "keyword"),
-        @Index(name = "idx_search_log_user_id", columnList = "userId"),
-        @Index(name = "idx_search_log_created_at", columnList = "createdAt")
+        @Index(name = "idx_search_log_user_id", columnList = "user_id"),
+        @Index(name = "idx_search_log_created_at", columnList = "created_at")
 })
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)


### PR DESCRIPTION
#### ⚠️ : 컬럼명 변경으로 인한 SearchLog 테이블 재생성이 필요합니다.

## 📌 개요
- Hibernate DDL 오류 해결을 위해 SearchLog 엔티티의 컬럼명 수정

## 👩‍💻 작업 사항
- [x] userId → user_id, createdAt → created_at으로 수정

## 🔗 관련 이슈
- close #244
