### PR TITLE
feat: 이벤트에 sellerId/sellerName 추가, Kafka ObjectMapper 중복 주석 처리

### DIFF
--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionCreateUseCase.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionCreateUseCase.java
@@ -2,11 +2,14 @@ package com.fourtune.auction.boundedContext.auction.application.service;
 
 import com.fourtune.auction.boundedContext.auction.domain.entity.AuctionItem;
 import com.fourtune.auction.boundedContext.auction.domain.entity.ItemImage;
+import com.fourtune.auction.boundedContext.user.application.service.UserFacade;
 import com.fourtune.auction.global.eventPublisher.EventPublisher;
 import com.fourtune.auction.shared.auction.dto.AuctionItemCreateRequest;
 import com.fourtune.auction.shared.auction.event.AuctionCreatedEvent;
 import com.fourtune.auction.shared.auction.event.AuctionItemCreatedEvent;
 import lombok.RequiredArgsConstructor;
+
+import java.util.Set;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +25,7 @@ public class AuctionCreateUseCase {
 
     private final AuctionSupport auctionSupport;
     private final EventPublisher eventPublisher;
+    private final UserFacade userFacade;
     // private final S3Service s3Service; // TODO: 나중에 추가
 
     /**
@@ -55,8 +59,11 @@ public class AuctionCreateUseCase {
         
         // 4. Search 인덱싱 전용 이벤트 발행 (스냅샷 형태)
         String thumbnailUrl = extractThumbnailUrl(savedAuction);
+        String sellerName = userFacade.getNicknamesByIds(Set.of(sellerId)).getOrDefault(sellerId, null);
         eventPublisher.publish(new AuctionItemCreatedEvent(
                 savedAuction.getId(),
+                sellerId,
+                sellerName,
                 savedAuction.getTitle(),
                 savedAuction.getDescription(),
                 savedAuction.getCategory(),

--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionUpdateUseCase.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionUpdateUseCase.java
@@ -2,8 +2,11 @@ package com.fourtune.auction.boundedContext.auction.application.service;
 
 import com.fourtune.auction.boundedContext.auction.domain.entity.AuctionItem;
 import com.fourtune.auction.boundedContext.auction.domain.entity.ItemImage;
+import com.fourtune.auction.boundedContext.user.application.service.UserFacade;
 import com.fourtune.auction.global.eventPublisher.EventPublisher;
 import com.fourtune.auction.shared.auction.dto.AuctionItemUpdateRequest;
+
+import java.util.Set;
 import com.fourtune.auction.shared.auction.event.AuctionUpdatedEvent;
 import com.fourtune.auction.shared.auction.event.AuctionItemUpdatedEvent;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +25,7 @@ public class AuctionUpdateUseCase {
     private final AuctionSupport auctionSupport;
     private final BidSupport bidSupport;
     private final EventPublisher eventPublisher;
+    private final UserFacade userFacade;
 
     /**
      * 경매 정보 수정
@@ -48,9 +52,11 @@ public class AuctionUpdateUseCase {
         // 5. DB 저장 (dirty checking으로 자동 저장)
         
         // 6. 이벤트 발행
+        String sellerName = userFacade.getNicknamesByIds(Set.of(auctionItem.getSellerId())).getOrDefault(auctionItem.getSellerId(), null);
         eventPublisher.publish(new AuctionUpdatedEvent(
                 auctionItem.getId(),
                 auctionItem.getSellerId(),
+                sellerName,
                 auctionItem.getTitle(),
                 auctionItem.getDescription(),
                 auctionItem.getBuyNowPrice(),

--- a/fourtune/src/main/java/com/fourtune/auction/global/config/kafka/KafkaConfig.java
+++ b/fourtune/src/main/java/com/fourtune/auction/global/config/kafka/KafkaConfig.java
@@ -35,11 +35,13 @@ public class KafkaConfig {
     @Value("${spring.kafka.consumer.group-id:fourtune-consumer-group}")
     private String consumerGroupId;
 
-    // ObjectMapper는 스프링 부트가 이미 만들어둔 빈을 주입받아도 됩니다.
-    @Bean
-    public ObjectMapper objectMapper() {
-        return new ObjectMapper();
-    }
+    // ObjectMapper는 JacksonConfig에서 정의한 단일 빈을 주입받음 (중복 빈 충돌 방지, JavaTimeModule로 UserEventMessage 등 날짜 필드 직렬화 보장)
+    // 상세: docs/reference/OBJECTMAPPER_KAFKA_JACKSON_ANALYSIS.md
+    // 혹시 모를 롤백용: 아래 주석 해제 시 이 클래스에서 ObjectMapper 빈 정의 (JacksonConfig와 중복 시 충돌)
+    // @Bean
+    // public ObjectMapper objectMapper() {
+    //     return new ObjectMapper();
+    // }
 
     // --- Producer 설정 ---
 

--- a/fourtune/src/main/java/com/fourtune/auction/shared/auction/event/AuctionItemCreatedEvent.java
+++ b/fourtune/src/main/java/com/fourtune/auction/shared/auction/event/AuctionItemCreatedEvent.java
@@ -13,6 +13,8 @@ import java.time.LocalDateTime;
  */
 public record AuctionItemCreatedEvent(
     Long auctionItemId,
+    Long sellerId,
+    String sellerName,
     String title,
     String description,
     Category category,

--- a/fourtune/src/main/java/com/fourtune/auction/shared/auction/event/AuctionUpdatedEvent.java
+++ b/fourtune/src/main/java/com/fourtune/auction/shared/auction/event/AuctionUpdatedEvent.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 public record AuctionUpdatedEvent(
     Long auctionId,
     Long sellerId,
+    String sellerName,
     String title,
     String description,
     BigDecimal buyNowPrice,

--- a/fourtune/src/test/java/com/fourtune/auction/boundedContext/search/adapter/in/event/AuctionItemIndexEventListenerTest.java
+++ b/fourtune/src/test/java/com/fourtune/auction/boundedContext/search/adapter/in/event/AuctionItemIndexEventListenerTest.java
@@ -105,6 +105,8 @@ class AuctionItemIndexEventListenerTest {
         LocalDateTime now = LocalDateTime.now();
         AuctionItemCreatedEvent event = new AuctionItemCreatedEvent(
                 100L,
+                1L,
+                "TestSeller",
                 "Complete Test Auction",
                 "Detailed description",
                 Category.ELECTRONICS,
@@ -149,6 +151,8 @@ class AuctionItemIndexEventListenerTest {
     private AuctionItemCreatedEvent createTestCreatedEvent() {
         return new AuctionItemCreatedEvent(
                 1L,
+                1L,
+                "TestSeller",
                 "Test Auction",
                 "Test Description",
                 Category.ELECTRONICS,


### PR DESCRIPTION
## 📌 개요
- 검색/CS 개선을 위해 경매 생성·수정 이벤트에 판매자 정보(sellerId, sellerName)를 포함하도록 변경

## 👩‍💻 작업 사항
- [x] `AuctionItemCreatedEvent`에 `sellerId`, `sellerName` 필드 추가
- [x] `AuctionUpdatedEvent`에 `sellerName` 필드 추가

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
