### PR TITLE
feat: 경매 목록 응답에 watchlistCount 추가

### DIFF
--- a/fourtune/src/main/java/com/fourtune/auction/shared/auction/dto/AuctionItemResponse.java
+++ b/fourtune/src/main/java/com/fourtune/auction/shared/auction/dto/AuctionItemResponse.java
@@ -20,6 +20,7 @@ public record AuctionItemResponse(
     AuctionStatus status,
     LocalDateTime auctionEndTime,
     Long viewCount,
+    Integer watchlistCount,
     Integer bidCount,
     String thumbnailUrl
 ) {
@@ -55,6 +56,7 @@ public record AuctionItemResponse(
                 auctionItem.getStatus(),
                 auctionItem.getAuctionEndTime(),
                 auctionItem.getViewCount(),
+                auctionItem.getWatchlistCount(),
                 auctionItem.getBidCount(),
                 thumbnailUrl
         );
@@ -67,7 +69,7 @@ public record AuctionItemResponse(
         return new AuctionItemResponse(
                 id, sellerId, sellerNickname, title, category,
                 startPrice, currentPrice, buyNowPrice, buyNowEnabled, buyNowDisabledByPolicy,
-                status, auctionEndTime, viewCount, bidCount, thumbnailUrl
+                status, auctionEndTime, viewCount, watchlistCount, bidCount, thumbnailUrl
         );
     }
 }


### PR DESCRIPTION
## 📌 개요
- 경매 목록 API(AuctionItemResponse)에는 조회수·입찰 수만 있고 관심 수(watchlistCount)가 없어, 목록에서도 관심 수를 노출할 수 있도록 DTO에 필드를 추가

## 👩‍💻 작업 사항
- [x] AuctionItemResponse에 watchlistCount 필드 추가

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
