### PR TITLE
feat: 경매 도메인 Kafka + Outbox 도입 (payload 래퍼 방식)

### DIFF
--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/kafka/AuctionEventCartOrderKafkaListener.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/kafka/AuctionEventCartOrderKafkaListener.java
@@ -1,0 +1,47 @@
+package com.fourtune.auction.boundedContext.auction.adapter.in.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fourtune.auction.boundedContext.auction.application.service.CartSupport;
+import com.fourtune.auction.global.config.kafka.KafkaTopicConfig;
+import com.fourtune.auction.shared.auction.event.AuctionClosedEvent;
+import com.fourtune.auction.shared.auction.kafka.AuctionEventMapper;
+import com.fourtune.auction.shared.auction.kafka.AuctionEventType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+/**
+ * 경매 이벤트 → 장바구니 만료 (Consumer Group: auction-cart-order)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "feature.kafka.auction-events.enabled", havingValue = "true", matchIfMissing = false)
+public class AuctionEventCartOrderKafkaListener {
+
+    private final CartSupport cartSupport;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(
+            topics = KafkaTopicConfig.AUCTION_EVENTS_TOPIC,
+            groupId = "auction-cart-order",
+            containerFactory = "auctionEventKafkaListenerContainerFactory"
+    )
+    public void consume(String payload, @Header(value = "X-Event-Type", required = false) String eventType) {
+        if (eventType == null || !eventType.equals(AuctionEventType.AUCTION_CLOSED.name())) {
+            return;
+        }
+        try {
+            AuctionClosedEvent event = (AuctionClosedEvent) objectMapper.readValue(
+                    payload, AuctionEventMapper.getClass(eventType));
+            cartSupport.expireCartItemsByAuctionId(event.auctionId());
+            log.debug("[auction-cart-order] Cart items expired: auctionId={}", event.auctionId());
+        } catch (Exception e) {
+            log.error("[auction-cart-order] Failed: eventType={}, error={}", eventType, e.getMessage(), e);
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionBuyNowUseCase.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionBuyNowUseCase.java
@@ -5,17 +5,21 @@ import com.fourtune.auction.boundedContext.auction.domain.constant.AuctionStatus
 import com.fourtune.auction.boundedContext.auction.domain.entity.AuctionItem;
 import com.fourtune.auction.boundedContext.auction.domain.entity.ItemImage;
 import com.fourtune.auction.boundedContext.user.application.service.UserFacade;
+import com.fourtune.auction.global.config.EventPublishingConfig;
 import com.fourtune.auction.global.error.ErrorCode;
 import com.fourtune.auction.global.error.exception.BusinessException;
 import com.fourtune.auction.global.eventPublisher.EventPublisher;
+import com.fourtune.auction.global.outbox.service.OutboxService;
 import com.fourtune.auction.shared.auction.event.AuctionBuyNowEvent;
 import com.fourtune.auction.shared.auction.event.AuctionItemUpdatedEvent;
+import com.fourtune.auction.shared.auction.kafka.AuctionEventType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -30,12 +34,16 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class AuctionBuyNowUseCase {
 
+    private static final String AGGREGATE_TYPE_AUCTION = "Auction";
+
     private final AuctionSupport auctionSupport;
     private final OrderSupport orderSupport;
     private final OrderCreateUseCase orderCreateUseCase;
     private final CartSupport cartSupport;
     private final EventPublisher eventPublisher;
     private final UserFacade userFacade;
+    private final EventPublishingConfig eventPublishingConfig;
+    private final OutboxService outboxService;
 
     /**
      * 즉시구매 처리
@@ -73,20 +81,24 @@ public class AuctionBuyNowUseCase {
         }
         
         // 6. 이벤트 발행 (AuctionBuyNowEvent)
-        eventPublisher.publish(new AuctionBuyNowEvent(
+        AuctionBuyNowEvent buyNowEvent = new AuctionBuyNowEvent(
                 auctionId,
                 auctionItem.getSellerId(),
                 buyerId,
                 auctionItem.getBuyNowPrice(),
                 orderId,
                 LocalDateTime.now()
-        ));
-        
+        );
+        if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+            outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.AUCTION_BUY_NOW.name(), Map.of("eventType", AuctionEventType.AUCTION_BUY_NOW.name(), "aggregateId", auctionId, "data", buyNowEvent));
+        } else {
+            eventPublisher.publish(buyNowEvent);
+        }
+
         // 7. Search 인덱싱 전용 이벤트 발행 (스냅샷 형태)
         String thumbnailUrl = extractThumbnailUrl(auctionItem);
         String sellerName = userFacade.getNicknamesByIds(Set.of(auctionItem.getSellerId())).getOrDefault(auctionItem.getSellerId(), null);
-
-        eventPublisher.publish(new AuctionItemUpdatedEvent(
+        AuctionItemUpdatedEvent itemUpdatedEvent = new AuctionItemUpdatedEvent(
                 auctionItem.getId(),
                 auctionItem.getSellerId(),
                 sellerName,
@@ -106,8 +118,13 @@ public class AuctionBuyNowUseCase {
                 auctionItem.getViewCount(),
                 auctionItem.getBidCount(),
                 auctionItem.getWatchlistCount()
-        ));
-        
+        );
+        if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+            outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.AUCTION_ITEM_UPDATED.name(), Map.of("eventType", AuctionEventType.AUCTION_ITEM_UPDATED.name(), "aggregateId", auctionId, "data", itemUpdatedEvent));
+        } else {
+            eventPublisher.publish(itemUpdatedEvent);
+        }
+
         log.info("즉시구매 처리 완료: auctionId={}, buyerId={}, orderId={}", auctionId, buyerId, orderId);
         
         // 8. orderId 반환 (결제 프로세스로 전달)

--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionCloseUseCase.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionCloseUseCase.java
@@ -4,14 +4,18 @@ import com.fourtune.auction.boundedContext.auction.domain.entity.AuctionItem;
 import com.fourtune.auction.boundedContext.auction.domain.entity.Bid;
 import com.fourtune.auction.boundedContext.auction.domain.entity.ItemImage;
 import com.fourtune.auction.boundedContext.user.application.service.UserFacade;
+import com.fourtune.auction.global.config.EventPublishingConfig;
 import com.fourtune.auction.global.eventPublisher.EventPublisher;
+import com.fourtune.auction.global.outbox.service.OutboxService;
 import com.fourtune.auction.shared.auction.event.AuctionClosedEvent;
 import com.fourtune.auction.shared.auction.event.AuctionItemUpdatedEvent;
+import com.fourtune.auction.shared.auction.kafka.AuctionEventType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Map;
 import java.util.Set;
 
 /**
@@ -25,11 +29,15 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class AuctionCloseUseCase {
 
+    private static final String AGGREGATE_TYPE_AUCTION = "Auction";
+
     private final AuctionSupport auctionSupport;
     private final BidSupport bidSupport;
     private final OrderCreateUseCase orderCreateUseCase;
     private final EventPublisher eventPublisher;
     private final UserFacade userFacade;
+    private final EventPublishingConfig eventPublishingConfig;
+    private final OutboxService outboxService;
 
     /**
      * 경매 종료 처리
@@ -69,20 +77,24 @@ public class AuctionCloseUseCase {
             bidSupport.failAllActiveBids(auctionId);
             
             // 이벤트 발행
-            eventPublisher.publish(new AuctionClosedEvent(
+            AuctionClosedEvent closedEvent = new AuctionClosedEvent(
                     auctionId,
                     auctionItem.getTitle(),
                     auctionItem.getSellerId(),
                     winningBid.getBidderId(),
                     winningBid.getBidAmount(),
                     orderId
-            ));
-            
+            );
+            if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+                outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.AUCTION_CLOSED.name(), Map.of("eventType", AuctionEventType.AUCTION_CLOSED.name(), "aggregateId", auctionId, "data", closedEvent));
+            } else {
+                eventPublisher.publish(closedEvent);
+            }
+
             // Search 인덱싱 전용 이벤트 발행 (스냅샷 형태)
             String thumbnailUrl = extractThumbnailUrl(auctionItem);
             String sellerName = userFacade.getNicknamesByIds(Set.of(auctionItem.getSellerId())).getOrDefault(auctionItem.getSellerId(), null);
-
-            eventPublisher.publish(new AuctionItemUpdatedEvent(
+            AuctionItemUpdatedEvent itemUpdatedEvent = new AuctionItemUpdatedEvent(
                     auctionItem.getId(),
                     auctionItem.getSellerId(),
                     sellerName,
@@ -102,26 +114,35 @@ public class AuctionCloseUseCase {
                     auctionItem.getViewCount(),
                     auctionItem.getBidCount(),
                     auctionItem.getWatchlistCount()
-            ));
+            );
+            if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+                outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.AUCTION_ITEM_UPDATED.name(), Map.of("eventType", AuctionEventType.AUCTION_ITEM_UPDATED.name(), "aggregateId", auctionId, "data", itemUpdatedEvent));
+            } else {
+                eventPublisher.publish(itemUpdatedEvent);
+            }
         } else {
             // 4-2. 낙찰자가 없는 경우 (입찰이 없었음)
             auctionItem.close();
-            
+
             // 이벤트 발행
-            eventPublisher.publish(new AuctionClosedEvent(
+            AuctionClosedEvent closedEventNoWinner = new AuctionClosedEvent(
                     auctionId,
                     auctionItem.getTitle(),
                     auctionItem.getSellerId(),
                     null,  // 낙찰자 없음
                     null,  // 낙찰가 없음
                     null   // 주문번호 없음
-            ));
-            
+            );
+            if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+                outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.AUCTION_CLOSED.name(), Map.of("eventType", AuctionEventType.AUCTION_CLOSED.name(), "aggregateId", auctionId, "data", closedEventNoWinner));
+            } else {
+                eventPublisher.publish(closedEventNoWinner);
+            }
+
             // Search 인덱싱 전용 이벤트 발행 (스냅샷 형태)
             String thumbnailUrl = extractThumbnailUrl(auctionItem);
             String sellerName = userFacade.getNicknamesByIds(java.util.Set.of(auctionItem.getSellerId())).getOrDefault(auctionItem.getSellerId(), null);
-
-            eventPublisher.publish(new AuctionItemUpdatedEvent(
+            AuctionItemUpdatedEvent itemUpdatedEventNoWinner = new AuctionItemUpdatedEvent(
                     auctionItem.getId(),
                     auctionItem.getSellerId(),
                     sellerName,
@@ -141,10 +162,15 @@ public class AuctionCloseUseCase {
                     auctionItem.getViewCount(),
                     auctionItem.getBidCount(),
                     auctionItem.getWatchlistCount()
-            ));
+            );
+            if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+                outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.AUCTION_ITEM_UPDATED.name(), Map.of("eventType", AuctionEventType.AUCTION_ITEM_UPDATED.name(), "aggregateId", auctionId, "data", itemUpdatedEventNoWinner));
+            } else {
+                eventPublisher.publish(itemUpdatedEventNoWinner);
+            }
         }
     }
-    
+
     /**
      * 썸네일 URL 추출
      */

--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/BidCancelUseCase.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/BidCancelUseCase.java
@@ -2,15 +2,19 @@ package com.fourtune.auction.boundedContext.auction.application.service;
 
 import com.fourtune.auction.boundedContext.auction.domain.constant.BidStatus;
 import com.fourtune.auction.boundedContext.auction.domain.entity.Bid;
+import com.fourtune.auction.global.config.EventPublishingConfig;
 import com.fourtune.auction.global.error.ErrorCode;
 import com.fourtune.auction.global.error.exception.BusinessException;
 import com.fourtune.auction.global.eventPublisher.EventPublisher;
+import com.fourtune.auction.global.outbox.service.OutboxService;
 import com.fourtune.auction.shared.auction.event.BidCanceledEvent;
+import com.fourtune.auction.shared.auction.kafka.AuctionEventType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
+import java.util.Map;
 
 /**
  * 입찰 취소 UseCase
@@ -21,9 +25,13 @@ import java.time.LocalDateTime;
 @RequiredArgsConstructor
 public class BidCancelUseCase {
 
+    private static final String AGGREGATE_TYPE_AUCTION = "Auction";
+
     private final BidSupport bidSupport;
     private final AuctionSupport auctionSupport;
     private final EventPublisher eventPublisher;
+    private final EventPublishingConfig eventPublishingConfig;
+    private final OutboxService outboxService;
 
     /**
      * 입찰 취소
@@ -46,15 +54,21 @@ public class BidCancelUseCase {
         var auctionItem = auctionSupport.findByIdOrThrow(bid.getAuctionId());
         
         // 6. 이벤트 발송
-        eventPublisher.publish(new BidCanceledEvent(
+        Long auctionId = bid.getAuctionId();
+        BidCanceledEvent canceledEvent = new BidCanceledEvent(
                 bid.getId(),
-                bid.getAuctionId(),
+                auctionId,
                 auctionItem.getTitle(),
                 auctionItem.getSellerId(),
                 bid.getBidderId(),
                 bid.getBidAmount(),
                 LocalDateTime.now()
-        ));
+        );
+        if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+            outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.BID_CANCELED.name(), Map.of("eventType", AuctionEventType.BID_CANCELED.name(), "aggregateId", auctionId, "data", canceledEvent));
+        } else {
+            eventPublisher.publish(canceledEvent);
+        }
     }
 
     /**

--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/BidPlaceUseCase.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/BidPlaceUseCase.java
@@ -6,11 +6,14 @@ import com.fourtune.auction.boundedContext.auction.domain.entity.AuctionItem;
 import com.fourtune.auction.boundedContext.auction.domain.entity.Bid;
 import com.fourtune.auction.boundedContext.auction.domain.entity.ItemImage;
 import com.fourtune.auction.boundedContext.user.application.service.UserFacade;
+import com.fourtune.auction.global.config.EventPublishingConfig;
 import com.fourtune.auction.global.error.ErrorCode;
 import com.fourtune.auction.global.error.exception.BusinessException;
 import com.fourtune.auction.global.eventPublisher.EventPublisher;
+import com.fourtune.auction.global.outbox.service.OutboxService;
 import com.fourtune.auction.shared.auction.event.BidPlacedEvent;
 import com.fourtune.auction.shared.auction.event.AuctionItemUpdatedEvent;
+import com.fourtune.auction.shared.auction.kafka.AuctionEventType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 
@@ -32,11 +36,15 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class BidPlaceUseCase {
 
+    private static final String AGGREGATE_TYPE_AUCTION = "Auction";
+
     private final AuctionSupport auctionSupport;
     private final BidSupport bidSupport;
     private final AuctionExtendUseCase auctionExtendUseCase;
     private final EventPublisher eventPublisher;
     private final UserFacade userFacade;
+    private final EventPublishingConfig eventPublishingConfig;
+    private final OutboxService outboxService;
 
     /**
      * 입찰 등록
@@ -81,7 +89,7 @@ public class BidPlaceUseCase {
         
         // 7. 이벤트 발행 (실시간 알림 등에 사용)
         Long previousBidderId = previousHighestBid.map(Bid::getBidderId).orElse(null);
-        eventPublisher.publish(new BidPlacedEvent(
+        BidPlacedEvent bidPlacedEvent = new BidPlacedEvent(
                 savedBid.getId(),
                 auctionId,
                 auctionItem.getTitle(),
@@ -90,13 +98,17 @@ public class BidPlaceUseCase {
                 previousBidderId,
                 bidAmount,
                 LocalDateTime.now()
-        ));
-        
+        );
+        if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+            outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.BID_PLACED.name(), Map.of("eventType", AuctionEventType.BID_PLACED.name(), "aggregateId", auctionId, "data", bidPlacedEvent));
+        } else {
+            eventPublisher.publish(bidPlacedEvent);
+        }
+
         // 8. Search 인덱싱 전용 이벤트 발행 (스냅샷 형태)
         String thumbnailUrl = extractThumbnailUrl(auctionItem);
         String sellerName = userFacade.getNicknamesByIds(Set.of(auctionItem.getSellerId())).getOrDefault(auctionItem.getSellerId(), null);
-
-        eventPublisher.publish(new AuctionItemUpdatedEvent(
+        AuctionItemUpdatedEvent itemUpdatedEvent = new AuctionItemUpdatedEvent(
                 auctionItem.getId(),
                 auctionItem.getSellerId(),
                 sellerName,
@@ -116,8 +128,13 @@ public class BidPlaceUseCase {
                 auctionItem.getViewCount(),
                 auctionItem.getBidCount(),
                 auctionItem.getWatchlistCount()
-        ));
-        
+        );
+        if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+            outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.AUCTION_ITEM_UPDATED.name(), Map.of("eventType", AuctionEventType.AUCTION_ITEM_UPDATED.name(), "aggregateId", auctionId, "data", itemUpdatedEvent));
+        } else {
+            eventPublisher.publish(itemUpdatedEvent);
+        }
+
         // 9. 입찰 ID 반환
         return savedBid.getId();
     }

--- a/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/OrderCompleteUseCase.java
+++ b/fourtune/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/OrderCompleteUseCase.java
@@ -4,16 +4,21 @@ import com.fourtune.auction.boundedContext.auction.domain.constant.AuctionPolicy
 import com.fourtune.auction.boundedContext.auction.domain.constant.AuctionStatus;
 import com.fourtune.auction.boundedContext.auction.domain.constant.OrderStatus;
 import com.fourtune.auction.boundedContext.auction.domain.entity.Order;
+import com.fourtune.auction.global.config.EventPublishingConfig;
 import com.fourtune.auction.global.error.ErrorCode;
 import com.fourtune.auction.global.error.exception.BusinessException;
 import com.fourtune.auction.global.eventPublisher.EventPublisher;
+import com.fourtune.auction.global.outbox.service.OutboxService;
 import com.fourtune.auction.shared.auction.constant.CancelReason;
 import com.fourtune.auction.shared.auction.event.OrderCancelledEvent;
 import com.fourtune.auction.shared.auction.event.OrderCompletedEvent;
+import com.fourtune.auction.shared.auction.kafka.AuctionEventType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
 
 /**
  * 주문 완료 UseCase
@@ -26,9 +31,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class OrderCompleteUseCase {
 
+    private static final String AGGREGATE_TYPE_AUCTION = "Auction";
+
     private final OrderSupport orderSupport;
     private final AuctionSupport auctionSupport;
     private final EventPublisher eventPublisher;
+    private final EventPublishingConfig eventPublishingConfig;
+    private final OutboxService outboxService;
 
     /**
      * 결제 완료 처리
@@ -50,16 +59,22 @@ public class OrderCompleteUseCase {
         orderSupport.save(order);
         
         // 5. 이벤트 발행 (정산, 알림 등에 사용)
-        eventPublisher.publish(new OrderCompletedEvent(
+        Long auctionId = order.getAuctionId();
+        OrderCompletedEvent completedEvent = new OrderCompletedEvent(
                 order.getOrderId(),
-                order.getAuctionId(),
+                auctionId,
                 order.getWinnerId(),
                 order.getSellerId(),
                 order.getAmount(),
                 order.getOrderName(),
                 order.getPaidAt()
-        ));
-        
+        );
+        if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+            outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.ORDER_COMPLETED.name(), Map.of("eventType", AuctionEventType.ORDER_COMPLETED.name(), "aggregateId", auctionId, "data", completedEvent));
+        } else {
+            eventPublisher.publish(completedEvent);
+        }
+
         log.info("결제 완료 처리: orderId={}, paymentKey={}", orderId, paymentKey);
     }
 
@@ -140,12 +155,18 @@ public class OrderCompleteUseCase {
         // 2. 기존대로 취소 + 경매 복구/유찰
         cancelOrderInternal(order);
         // 3. 제보: 취소 사유를 담아 OrderCancelledEvent 발행
-        eventPublisher.publish(new OrderCancelledEvent(
+        Long auctionId = order.getAuctionId();
+        OrderCancelledEvent cancelledEvent = new OrderCancelledEvent(
                 order.getWinnerId(),
                 order.getId(),
-                order.getAuctionId(),
+                auctionId,
                 reason
-        ));
+        );
+        if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+            outboxService.append(AGGREGATE_TYPE_AUCTION, auctionId, AuctionEventType.ORDER_CANCELLED.name(), Map.of("eventType", AuctionEventType.ORDER_CANCELLED.name(), "aggregateId", auctionId, "data", cancelledEvent));
+        } else {
+            eventPublisher.publish(cancelledEvent);
+        }
         log.info("만료된 주문 자동 취소: orderId={}, reason={}", orderId, reason);
     }
 

--- a/fourtune/src/main/java/com/fourtune/auction/global/config/EventPublishingConfig.java
+++ b/fourtune/src/main/java/com/fourtune/auction/global/config/EventPublishingConfig.java
@@ -18,11 +18,21 @@ public class EventPublishingConfig {
     @Value("${feature.kafka.user-events.enabled:false}")
     private boolean userEventsKafkaEnabled;
 
+    @Value("${feature.kafka.auction-events.enabled:false}")
+    private boolean auctionEventsKafkaEnabled;
+
     /**
      * User 이벤트에 대해 Kafka를 사용할지 여부
      */
     public boolean isUserEventsKafkaEnabled() {
         return kafkaEnabled && userEventsKafkaEnabled;
+    }
+
+    /**
+     * 경매 이벤트에 대해 Kafka를 사용할지 여부
+     */
+    public boolean isAuctionEventsKafkaEnabled() {
+        return kafkaEnabled && auctionEventsKafkaEnabled;
     }
 
     /**

--- a/fourtune/src/main/java/com/fourtune/auction/global/config/kafka/KafkaTopicConfig.java
+++ b/fourtune/src/main/java/com/fourtune/auction/global/config/kafka/KafkaTopicConfig.java
@@ -13,6 +13,9 @@ public class KafkaTopicConfig {
     public static final String USER_EVENTS_TOPIC = "user-account-events";
     public static final String USER_EVENTS_DLQ_TOPIC = "user-events-dlq";
 
+    public static final String AUCTION_EVENTS_TOPIC = "auction-events";
+    public static final String AUCTION_EVENTS_DLQ_TOPIC = "auction-events-dlq";
+
     @Bean
     public NewTopic userEventsTopic() {
         return TopicBuilder.name(USER_EVENTS_TOPIC)
@@ -24,6 +27,22 @@ public class KafkaTopicConfig {
     @Bean
     public NewTopic userEventsDlqTopic() {
         return TopicBuilder.name(USER_EVENTS_DLQ_TOPIC)
+                .partitions(1)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic auctionEventsTopic() {
+        return TopicBuilder.name(AUCTION_EVENTS_TOPIC)
+                .partitions(3)
+                .replicas(1)
+                .build();
+    }
+
+    @Bean
+    public NewTopic auctionEventsDlqTopic() {
+        return TopicBuilder.name(AUCTION_EVENTS_DLQ_TOPIC)
                 .partitions(1)
                 .replicas(1)
                 .build();

--- a/fourtune/src/main/java/com/fourtune/auction/global/outbox/service/OutboxPublisher.java
+++ b/fourtune/src/main/java/com/fourtune/auction/global/outbox/service/OutboxPublisher.java
@@ -54,7 +54,7 @@ public class OutboxPublisher {
     @Scheduled(fixedDelayString = "${outbox.publisher.poll-interval-ms:1000}")
     @Transactional
     public void publishPendingEvents() {
-        if (!eventPublishingConfig.isUserEventsKafkaEnabled()) {
+        if (!eventPublishingConfig.isUserEventsKafkaEnabled() && !eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
             return;
         }
 
@@ -88,7 +88,7 @@ public class OutboxPublisher {
     @Scheduled(fixedRate = 30000)
     @Transactional
     public void retryFailedEvents() {
-        if (!eventPublishingConfig.isUserEventsKafkaEnabled()) {
+        if (!eventPublishingConfig.isUserEventsKafkaEnabled() && !eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
             return;
         }
 

--- a/fourtune/src/main/java/com/fourtune/auction/shared/auction/kafka/AuctionEventMapper.java
+++ b/fourtune/src/main/java/com/fourtune/auction/shared/auction/kafka/AuctionEventMapper.java
@@ -1,0 +1,48 @@
+package com.fourtune.auction.shared.auction.kafka;
+
+import com.fourtune.auction.shared.auction.event.*;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Kafka Consumer 역직렬화용: eventType 문자열 → 이벤트 Class 매핑
+ */
+@Slf4j
+public final class AuctionEventMapper {
+
+    private static final Map<String, Class<?>> TYPE_TO_CLASS = new ConcurrentHashMap<>();
+
+    static {
+        TYPE_TO_CLASS.put(AuctionEventType.BID_PLACED.name(), BidPlacedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.AUCTION_CREATED.name(), AuctionCreatedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.AUCTION_ITEM_CREATED.name(), AuctionItemCreatedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.AUCTION_ITEM_UPDATED.name(), AuctionItemUpdatedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.AUCTION_ITEM_DELETED.name(), AuctionItemDeletedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.AUCTION_UPDATED.name(), AuctionUpdatedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.AUCTION_STARTED.name(), AuctionStartedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.AUCTION_EXTENDED.name(), AuctionExtendedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.AUCTION_CLOSED.name(), AuctionClosedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.AUCTION_DELETED.name(), AuctionDeletedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.AUCTION_BUY_NOW.name(), AuctionBuyNowEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.BID_CANCELED.name(), BidCanceledEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.ORDER_COMPLETED.name(), OrderCompletedEvent.class);
+        TYPE_TO_CLASS.put(AuctionEventType.ORDER_CANCELLED.name(), OrderCancelledEvent.class);
+    }
+
+    private AuctionEventMapper() {
+    }
+
+    /**
+     * eventType 문자열에 해당하는 이벤트 Class 반환 (Consumer 역직렬화 시 사용)
+     */
+    public static Class<?> getClass(String eventType) {
+        Class<?> clazz = TYPE_TO_CLASS.get(eventType);
+        if (clazz == null) {
+            log.warn("알 수 없는 경매 이벤트 타입: {}", eventType);
+            throw new IllegalArgumentException("Unknown auction event type: " + eventType);
+        }
+        return clazz;
+    }
+}

--- a/fourtune/src/main/java/com/fourtune/auction/shared/auction/kafka/AuctionEventPayload.java
+++ b/fourtune/src/main/java/com/fourtune/auction/shared/auction/kafka/AuctionEventPayload.java
@@ -1,0 +1,20 @@
+package com.fourtune.auction.shared.auction.kafka;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 경매 Outbox payload 래퍼 (User/Outbox 인터페이스 변경 없이 사용)
+ * UseCase에서 append 시 Map으로 이 구조를 저장하고, Handler에서 payload 문자열만 받아 역직렬화할 때 사용
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuctionEventPayload {
+
+    private String eventType;
+    private Long aggregateId;
+    private JsonNode data;
+}

--- a/fourtune/src/main/java/com/fourtune/auction/shared/auction/kafka/AuctionEventType.java
+++ b/fourtune/src/main/java/com/fourtune/auction/shared/auction/kafka/AuctionEventType.java
@@ -1,0 +1,22 @@
+package com.fourtune.auction.shared.auction.kafka;
+
+/**
+ * 경매 도메인 Outbox/Kafka 이벤트 타입
+ * shared/auction/event 패키지의 이벤트 클래스명과 1:1 매핑 (BidCanceledEvent, OrderCancelledEvent 스펠링 유지)
+ */
+public enum AuctionEventType {
+    BID_PLACED,
+    AUCTION_CREATED,
+    AUCTION_ITEM_CREATED,
+    AUCTION_ITEM_UPDATED,
+    AUCTION_ITEM_DELETED,
+    AUCTION_UPDATED,
+    AUCTION_STARTED,
+    AUCTION_EXTENDED,
+    AUCTION_CLOSED,
+    AUCTION_DELETED,
+    AUCTION_BUY_NOW,
+    BID_CANCELED,
+    ORDER_COMPLETED,
+    ORDER_CANCELLED
+}

--- a/fourtune/src/main/java/com/fourtune/auction/shared/auction/kafka/AuctionKafkaProducer.java
+++ b/fourtune/src/main/java/com/fourtune/auction/shared/auction/kafka/AuctionKafkaProducer.java
@@ -1,0 +1,62 @@
+package com.fourtune.auction.shared.auction.kafka;
+
+import com.fourtune.auction.global.config.kafka.KafkaTopicConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * 경매 이벤트 Kafka Producer
+ * 파티션 키로 auctionId(aggregateId)를 사용하여 같은 경매 내 이벤트 순서 보장
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "feature.kafka.enabled", havingValue = "true", matchIfMissing = false)
+public class AuctionKafkaProducer {
+
+    private static final String HEADER_EVENT_TYPE = "X-Event-Type";
+
+    private final KafkaTemplate<String, String> auctionKafkaTemplate;
+
+    /**
+     * 경매 이벤트 발행 (payload = JSON 문자열, Header에 X-Event-Type 포함)
+     */
+    public CompletableFuture<?> send(String key, String payload, String eventType) {
+        Message<String> message = MessageBuilder
+                .withPayload(payload)
+                .setHeader(KafkaHeaders.TOPIC, KafkaTopicConfig.AUCTION_EVENTS_TOPIC)
+                .setHeader(KafkaHeaders.KEY, key)
+                .setHeader(HEADER_EVENT_TYPE, eventType)
+                .build();
+        return auctionKafkaTemplate.send(message)
+                .whenComplete((result, ex) -> {
+                    if (ex == null) {
+                        log.debug("Auction 이벤트 발행 성공: topic={}, key={}, eventType={}",
+                                KafkaTopicConfig.AUCTION_EVENTS_TOPIC, key, eventType);
+                    } else {
+                        log.error("Auction 이벤트 발행 실패: topic={}, key={}, eventType={}, error={}",
+                                KafkaTopicConfig.AUCTION_EVENTS_TOPIC, key, eventType, ex.getMessage(), ex);
+                    }
+                });
+    }
+
+    /**
+     * 동기 발행 (OutboxPublisher에서 사용)
+     */
+    public void sendSync(String key, String payload, String eventType) {
+        try {
+            send(key, payload, eventType).get();
+        } catch (Exception e) {
+            log.error("Auction 이벤트 동기 발행 실패: key={}, eventType={}", key, eventType, e);
+            throw new RuntimeException("Auction Kafka 메시지 발행 실패", e);
+        }
+    }
+}

--- a/fourtune/src/main/java/com/fourtune/auction/shared/auction/kafka/AuctionOutboxEventHandler.java
+++ b/fourtune/src/main/java/com/fourtune/auction/shared/auction/kafka/AuctionOutboxEventHandler.java
@@ -1,0 +1,39 @@
+package com.fourtune.auction.shared.auction.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fourtune.auction.global.outbox.handler.OutboxEventHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * 경매 도메인 Outbox 이벤트 핸들러
+ * payload = {"eventType":"...","aggregateId":123,"data":{...}} 형태로 저장된 JSON을 파싱 후 Kafka 발행
+ * (User/Outbox 인터페이스 변경 없이 handle(String payload)만 사용)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "feature.kafka.enabled", havingValue = "true", matchIfMissing = false)
+public class AuctionOutboxEventHandler implements OutboxEventHandler {
+
+    private static final String AGGREGATE_TYPE = "Auction";
+
+    private final AuctionKafkaProducer auctionKafkaProducer;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String getAggregateType() {
+        return AGGREGATE_TYPE;
+    }
+
+    @Override
+    public void handle(String payload) throws Exception {
+        AuctionEventPayload wrapper = objectMapper.readValue(payload, AuctionEventPayload.class);
+        String key = String.valueOf(wrapper.getAggregateId());
+        String eventType = wrapper.getEventType();
+        String value = objectMapper.writeValueAsString(wrapper.getData());
+        auctionKafkaProducer.sendSync(key, value, eventType);
+    }
+}

--- a/fourtune/src/main/resources/application.yml
+++ b/fourtune/src/main/resources/application.yml
@@ -82,6 +82,8 @@ feature:
     enabled: false
     user-events:
       enabled: false
+    auction-events:
+      enabled: false
 
 # Outbox 설정
 outbox:


### PR DESCRIPTION
## 📌 개요
- 경매 이벤트를 Spring Event 외에 Kafka + Outbox로도 발행 가능
- 이벤트 유실 방지, 트래픽 완충, 역할별 격리(알림/인덱싱 등)를 위해 Outbox 패턴과 Kafka 도입

## 👩‍💻 작업 사항
- [x] EventPublishingConfig에 feature.kafka.auction-events.enabled 플래그 및 isAuctionEventsKafkaEnabled() 추가
- [x] KafkaTopicConfig에 auction-events, auction-events-dlq 토픽 Bean 추가
- [x] OutboxPublisher가 User 또는 Auction 중 하나라도 활성화 시 폴링하도록 조건 수정
- [x] shared/auction/kafka/ 신규: AuctionEventPayload, AuctionEventType, AuctionEventMapper, AuctionKafkaProducer, AuctionOutboxEventHandler
- [x] 경매 UseCase 10곳에서 isAuctionEventsKafkaEnabled() 분기 및 Outbox append(payload 래퍼) 적용, 기존 eventPublisher.publish 유지
- [x] application.yml에 feature.kafka.auction-events.enabled: false 추가
- [x] auction BC Kafka Consumer 추가: AuctionEventCartOrderKafkaListener (group-id: auction-cart-order, X-Event-Type 헤더 + AuctionEventMapper 역직렬화)

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
