### PR TITLE
refactor: ARG MODULE_NAME 전역으로 선언

### DIFF
--- a/fourtune/Dockerfile
+++ b/fourtune/Dockerfile
@@ -1,9 +1,9 @@
 # Build stage
+ARG MODULE_NAME
+
 FROM eclipse-temurin:25-jdk-alpine AS builder
 
 WORKDIR /app
-
-ARG MODULE_NAME
 
 # Copy Gradle wrapper and build files
 COPY gradlew .
@@ -28,7 +28,6 @@ FROM eclipse-temurin:25-jre-alpine
 
 WORKDIR /app
 
-ARG MODULE_NAME
 # Add non-root user for security
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring


### PR DESCRIPTION
## 📌 개요
- 모듈 분리 후 ci-cd Deploy 과정에서 오류 발생함. 모듈 별로 도커 이미지 생성, jar 생성을 나누어놨는데 module name을 인식 못하는 상황(로컬에서 이미지 build 하면 잘 작동함)

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
