### PR TITLE
refactor: ARG MODULE_NAME from 절 안에 각각 선언

### DIFF
--- a/fourtune/Dockerfile
+++ b/fourtune/Dockerfile
@@ -3,6 +3,8 @@ ARG MODULE_NAME
 
 FROM eclipse-temurin:25-jdk-alpine AS builder
 
+ARG MODULE_NAME
+
 WORKDIR /app
 
 # Copy Gradle wrapper and build files
@@ -25,6 +27,8 @@ RUN ./gradlew :${MODULE_NAME}:bootjar -x test --no-daemon
 
 # Runtime stage
 FROM eclipse-temurin:25-jre-alpine
+
+ARG MODULE_NAME
 
 WORKDIR /app
 


### PR DESCRIPTION
## 📌 개요
- ARG를 DockerFile 가장 위에 선언했지만 DockerFile 에서는 일반 클래스와 달리 전역 변수 선언한다고 안에서 다 사용못해서 from 절마다 선언해줌

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
