### PR TITLE
refactor: SearchLog 엔티티에서 PostgreSQL 전용 text[] 타입 정의 제거

### DIFF
--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/domain/SearchLog.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/domain/SearchLog.java
@@ -35,7 +35,6 @@ public class SearchLog {
     private String keyword;
 
     @JdbcTypeCode(SqlTypes.ARRAY)
-    @Column(columnDefinition = "text[]")
     private List<String> categories;
 
     @Column(nullable = false)
@@ -44,7 +43,6 @@ public class SearchLog {
     private BigDecimal maxPrice; // null 가능 (상한 없음)
 
     @JdbcTypeCode(SqlTypes.ARRAY)
-    @Column(columnDefinition = "text[]")
     private List<String> status;
 
     @Column(nullable = false)


### PR DESCRIPTION
## 📌 개요
- 작업 예정 : postgreSQL 전용 text[] 타입 정의를 제거했습니다.

### 목적
특정 DB인 PostgreSQL에 종속적인 text[] 구문 대신 Hibernate 표준 배열 매핑(@JdbcTypeCode)을 사용하여, ORM 추상화 수준을 높이고 테스트 환경 호환성을 개선했습니다.

### 리팩토링 사유
 1. Hibernate 6 표준 활용 (Standardization)
    - Hibernate 6.x 부터는 SqlTypes.ARRAY를 통해 배열 타입을 표준적으로 지원함. 이제는 굳이 DDL을 하드코딩하지 않아도, Hibernate가 알아서 PostgreSQL Dialect를 감지하고 동일하게 text[] (또는 varchar array) 타입으로 매핑해 줌. 즉, 성능 이점은 그대로 가져가면서 코드는 더 깔끔해짐.
 2. 테스트 환경 이식성 (Portability)
    -  text[]는 PostgreSQL 전용 문법이라 H2 같은 인메모리 DB에서 테스트할 때 에러가 발생함. 표준 어노테이션을 쓰면, 운영 환경은 PostgreSQL Array, 테스트 환경은 H2 Array로 자동 변환되어 테스트 격리성을 확보하기 유리해짐
    - H2 Database 호환: text[]는 PostgreSQL 전용 문법이라 H2 같은 인메모리 DB에서 테스트할 때 에러가 발생합니다.
표준 어노테이션을 쓰면, 운영 환경은 PostgreSQL Array, 테스트 환경은 H2 Array로 자동 변환되어 테스트 격리성을 확보하기 유리함


## 👩‍💻 작업 사항
- [x] SearchLog 엔티티에서 PostgreSQL 전용 text[] 타입 정의 제거

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #269
