### PR TITLE
chore: Feign 버전 전환을 통한 Spring boot 버전과의 충돌 오류 해결

### DIFF
--- a/fourtune/build.gradle
+++ b/fourtune/build.gradle
@@ -22,7 +22,7 @@ subprojects {
 	ext {
 		querydslVersion = '5.0.0'
 		jwtVersion = '0.12.3'
-		openFeignVersion = '3.1.8'
+		openFeignVersion = '5.0.1'
 	}
 
 	java {


### PR DESCRIPTION
## 📌 개요
- Feign 버전 전환을 통해 Spring boot 버전과의 충돌을 해결하여, 애플리케이션이 정상적으로 실행할 수 있도록 했습니다.

## 👩‍💻 작업 사항
- [x] Spring Boot 버전인 4.0.1과 호환되도록, Feign 버전을 3.1.8에서 5.0.1로 전환

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #296
