### PR TITLE
chore: 개발서버 cicd 수정 (#287)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -223,7 +223,8 @@ jobs:
           key: ${{ secrets.DEV_SSH_KEY }}
           script: |
             cd /home/fourtune/fourtune || exit 1
-            git pull origin develop || exit 1
+            git fetch origin || exit 1
+            git reset --hard origin/develop || exit 1
             docker-compose -f docker-compose.dev.yml build app || exit 1
             docker-compose -f docker-compose.dev.yml up -d || exit 1
             docker system prune -af


### PR DESCRIPTION
## 📌 개요
-기존 git pull 방식은 로컬에 변경사항이 있거나 충돌 발생 시 merge 과정에서 실패하거나 서버가 애매한 상태로 남을 수 있는 문제
- 충돌 없이 원격 브랜치 상태로 강제 동기화하기 때문에 서버에 수동으로 변경된 파일이 있어도 전부 덮어써서 배포 스크립트가 중간에 멈추는 상황을 방지

## 👩‍💻 작업 사항
- 기존
git pull origin develop

- 변경
git fetch origin
git reset --hard origin/develop

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
