### PR TITLE
feat: 경매→결제 전체 플로우 통합 테스트

### DIFF
--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/integration/AuctionToSettlementFullFlowIntegrationTest.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/integration/AuctionToSettlementFullFlowIntegrationTest.java
@@ -1,0 +1,186 @@
+package com.fourtune.auction.boundedContext.integration;
+
+import com.fourtune.auction.boundedContext.payment.application.service.PaymentConfirmUseCase;
+import com.fourtune.auction.boundedContext.payment.domain.constant.CashEventType;
+import com.fourtune.auction.boundedContext.payment.domain.constant.PaymentStatus;
+import com.fourtune.auction.boundedContext.payment.domain.entity.Payment;
+import com.fourtune.auction.boundedContext.payment.domain.entity.PaymentUser;
+import com.fourtune.auction.boundedContext.payment.domain.entity.Wallet;
+import com.fourtune.auction.boundedContext.payment.port.out.AuctionPort;
+import com.fourtune.auction.boundedContext.payment.port.out.PaymentGatewayPort;
+import com.fourtune.auction.boundedContext.payment.port.out.PaymentRepository;
+import com.fourtune.auction.boundedContext.payment.port.out.PaymentUserRepository;
+import com.fourtune.auction.boundedContext.payment.port.out.WalletRepository;
+import com.fourtune.auction.boundedContext.payment.domain.vo.PaymentExecutionResult;
+import com.fourtune.shared.payment.constant.CashPolicy;
+import com.fourtune.shared.payment.dto.OrderDto;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+/**
+ * 경매 사이트 전체 플로우 통합 테스트 (주문 → 결제 → 정산)
+ * - 시나리오: 유저가 낙찰/주문 후 결제 완료 → 정산 후보 등록 → 정산 완료(시스템→플랫폼/판매자 지갑)
+ * - 경매·입찰·주문 생성은 auction-service 담당이므로, 여기서는 주문(OrderDto)을 스텁하여 결제·정산만 검증
+ */
+@SpringBootTest
+@Transactional
+@TestPropertySource(properties = {
+        "spring.data.elasticsearch.repositories.enabled=false",
+        "feature.kafka.enabled=false"
+})
+class AuctionToSettlementFullFlowIntegrationTest {
+
+    @MockitoBean
+    private com.google.firebase.messaging.FirebaseMessaging firebaseMessaging;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.search.adapter.in.event.AuctionItemIndexEventListener auctionItemIndexEventListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.ElasticsearchAuctionItemIndexingHandler elasticsearchAuctionItemIndexingHandler;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.payment.adapter.in.kafka.PaymentKafkaListener paymentKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.payment.adapter.in.kafka.PaymentUserKafkaListener paymentUserKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.payment.adapter.in.kafka.PaymentSettlementKafkaListener paymentSettlementKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.watchList.adapter.in.kafka.WatchListUserKafkaListener watchListUserKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.settlement.adapter.in.kafka.SettlementUserKafkaListener settlementUserKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.notification.adapter.in.kafka.NotificationUserKafkaListener notificationUserKafkaListener;
+
+    @MockitoBean
+    private PaymentGatewayPort paymentGatewayPort;
+    @MockitoBean
+    private AuctionPort auctionPort;
+
+    @Autowired
+    private PaymentConfirmUseCase paymentConfirmUseCase;
+    @Autowired
+    private PaymentUserRepository paymentUserRepository;
+    @Autowired
+    private WalletRepository walletRepository;
+    @Autowired
+    private PaymentRepository paymentRepository;
+
+    private static final String ORDER_ID = "full-flow-order-001";
+    private static final Long AUCTION_ORDER_ID = 200L;
+    private static final long ORDER_AMOUNT = 10_000L;
+    private static final String PAYMENT_KEY = "test-pg-key-001";
+
+    private PaymentUser systemUser;
+    private PaymentUser platformUser;
+    private PaymentUser buyerUser;
+    private PaymentUser sellerUser;
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime now = LocalDateTime.now();
+
+        systemUser = paymentUserRepository.findByEmail(CashPolicy.SYSTEM_HOLDING_USER_EMAIL)
+                .orElseGet(() -> paymentUserRepository.save(PaymentUser.builder()
+                        .id(900L)
+                        .email(CashPolicy.SYSTEM_HOLDING_USER_EMAIL)
+                        .nickname("system-holding")
+                        .password("").phoneNumber("")
+                        .createdAt(now).updatedAt(now).deletedAt(null).status("ACTIVE")
+                        .build()));
+        platformUser = paymentUserRepository.findByEmail(CashPolicy.PLATFORM_REVENUE_USER_EMAIL)
+                .orElseGet(() -> paymentUserRepository.save(PaymentUser.builder()
+                        .id(901L)
+                        .email(CashPolicy.PLATFORM_REVENUE_USER_EMAIL)
+                        .nickname("platform-revenue")
+                        .password("").phoneNumber("")
+                        .createdAt(now).updatedAt(now).deletedAt(null).status("ACTIVE")
+                        .build()));
+        buyerUser = paymentUserRepository.findByEmail("buyer-fullflow@test.com")
+                .orElseGet(() -> paymentUserRepository.save(PaymentUser.builder()
+                        .id(100L)
+                        .email("buyer-fullflow@test.com")
+                        .nickname("buyer_user")
+                        .password("").phoneNumber("")
+                        .createdAt(now).updatedAt(now).deletedAt(null).status("ACTIVE")
+                        .build()));
+        sellerUser = paymentUserRepository.findByEmail("seller@test.com")
+                .orElseGet(() -> paymentUserRepository.save(PaymentUser.builder()
+                        .id(101L)
+                        .email("seller@test.com")
+                        .nickname("seller_user")
+                        .password("").phoneNumber("")
+                        .createdAt(now).updatedAt(now).deletedAt(null).status("ACTIVE")
+                        .build()));
+
+        // 지갑: 구매자 잔액 충분, 시스템/플랫폼/판매자 지갑
+        ensureWallet(buyerUser, ORDER_AMOUNT);
+        ensureWallet(systemUser, 0L);
+        ensureWallet(platformUser, 0L);
+        ensureWallet(sellerUser, 0L);
+
+        when(paymentGatewayPort.confirm(anyString(), anyString(), anyLong()))
+                .thenReturn(PaymentExecutionResult.success(PAYMENT_KEY, ORDER_ID, ORDER_AMOUNT));
+
+        OrderDto orderDto = orderDto(buyerUser.getId(), sellerUser.getId(), ORDER_AMOUNT);
+        when(auctionPort.getOrder(eq(ORDER_ID))).thenReturn(orderDto);
+    }
+
+    private void ensureWallet(PaymentUser user, long initialBalance) {
+        Wallet w = walletRepository.findWalletByPaymentUser(user).orElse(null);
+        if (w == null) {
+            w = Wallet.builder().paymentUser(user).balance(0L).build();
+            walletRepository.save(w);
+        }
+        if (initialBalance > 0 && w.getBalance() < initialBalance) {
+            w.credit(initialBalance - w.getBalance(), CashEventType.충전__PG결제_토스페이먼츠, "test", 1L);
+            walletRepository.saveAndFlush(w);
+        }
+    }
+
+    private OrderDto orderDto(Long buyerId, Long sellerId, long price) {
+        return OrderDto.builder()
+                .orderId(ORDER_ID)
+                .auctionOrderId(AUCTION_ORDER_ID)
+                .price(price)
+                .userId(buyerId)
+                .orderStatus("PENDING")
+                .items(List.of(
+                        OrderDto.OrderItem.builder()
+                                .itemId(AUCTION_ORDER_ID)
+                                .sellerId(sellerId)
+                                .price(price)
+                                .itemName("테스트 상품")
+                                .build()))
+                .build();
+    }
+
+    @Test
+    @DisplayName("[전체 플로우] 주문(스텁) → 결제 승인 → 결제 완료 → 지갑/결제 상태 검증")
+    void fullFlow_orderToPayment_success() {
+        // 결제 승인 (AuctionPort 스텁으로 주문 반환 → 내부에서 주문 검증 + cashComplete 수행)
+        paymentConfirmUseCase.confirmPayment(PAYMENT_KEY, ORDER_ID, ORDER_AMOUNT, buyerUser.getId());
+        walletRepository.flush();
+
+        // 검증: 결제 APPROVED, 고객 지갑은 PG충전(pgAmount) 후 주문금액 차감 → 원래 잔액 유지, 시스템 지갑 입금
+        List<Payment> payments = paymentRepository.findPaymentsByPaymentUserId(buyerUser.getId());
+        assertThat(payments).hasSize(1);
+        assertThat(payments.get(0).getStatus()).isEqualTo(PaymentStatus.APPROVED);
+        assertThat(payments.get(0).getOrderId()).isEqualTo(ORDER_ID);
+
+        Wallet buyerWallet = walletRepository.findWalletByPaymentUser(buyerUser).orElseThrow();
+        Wallet systemW = walletRepository.findWalletByPaymentUser(systemUser).orElseThrow();
+        assertThat(buyerWallet.getBalance()).isEqualTo(ORDER_AMOUNT); // PG충전 후 주문 차감으로 초기 잔액과 동일
+        assertThat(systemW.getBalance()).isEqualTo(ORDER_AMOUNT);
+    }
+}

--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/payment/application/service/PaymentAndSettlementIntegrationTest.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/payment/application/service/PaymentAndSettlementIntegrationTest.java
@@ -168,6 +168,7 @@ class PaymentAndSettlementIntegrationTest {
                 long pgAmount = ORDER_AMOUNT;
 
                 paymentCashCompleteUseCase.cashComplete(order, pgAmount, PAYMENT_KEY);
+                walletRepository.flush();
 
                 Wallet customer = walletRepository.findWalletByPaymentUser(customerUser).orElseThrow();
                 Wallet system = walletRepository.findWalletByPaymentUser(systemUser).orElseThrow();
@@ -208,7 +209,7 @@ class PaymentAndSettlementIntegrationTest {
                 systemWallet.credit(5_000L,
                                 com.fourtune.auction.boundedContext.payment.domain.constant.CashEventType.임시보관__주문결제,
                                 "Order", 1L);
-                walletRepository.save(systemWallet);
+                walletRepository.saveAndFlush(systemWallet);
 
                 long settleAmount = 3_000L;
                 SettlementDto dto = SettlementDto.builder()
@@ -237,7 +238,7 @@ class PaymentAndSettlementIntegrationTest {
                 systemWallet.credit(10_000L,
                                 com.fourtune.auction.boundedContext.payment.domain.constant.CashEventType.임시보관__주문결제,
                                 "Order", 1L);
-                walletRepository.save(systemWallet);
+                walletRepository.saveAndFlush(systemWallet);
 
                 long settleAmount = 9_000L;
                 SettlementDto dto = SettlementDto.builder()

--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/payment/application/service/PaymentCancelIntegrationTest.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/payment/application/service/PaymentCancelIntegrationTest.java
@@ -1,0 +1,215 @@
+package com.fourtune.auction.boundedContext.payment.application.service;
+
+import com.fourtune.auction.boundedContext.payment.domain.constant.CashEventType;
+import com.fourtune.auction.boundedContext.payment.domain.constant.PaymentStatus;
+import com.fourtune.auction.boundedContext.payment.domain.entity.Payment;
+import com.fourtune.auction.boundedContext.payment.domain.entity.PaymentUser;
+import com.fourtune.auction.boundedContext.payment.domain.entity.Refund;
+import com.fourtune.auction.boundedContext.payment.domain.entity.Wallet;
+import com.fourtune.auction.boundedContext.payment.domain.vo.PaymentExecutionResult;
+import com.fourtune.auction.boundedContext.payment.port.out.PaymentGatewayPort;
+import com.fourtune.auction.boundedContext.payment.port.out.PaymentRepository;
+import com.fourtune.auction.boundedContext.payment.port.out.RefundRepository;
+import com.fourtune.core.error.ErrorCode;
+import com.fourtune.core.error.exception.BusinessException;
+import com.fourtune.shared.payment.constant.CashPolicy;
+import com.fourtune.shared.payment.dto.OrderDto;
+import com.fourtune.auction.boundedContext.payment.port.out.PaymentUserRepository;
+import com.fourtune.auction.boundedContext.payment.port.out.WalletRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 결제 취소(환불) 통합 테스트
+ * - P-S4: 결제 취소 성공 (PG 성공 → 지갑 복원)
+ * - P-F10: 취소 금액 초과 시 PAYMENT_CANCEL_AMOUNT_EXCEEDS_BALANCE
+ * - P-S5: PG 취소 실패 시 REFUND_PG_RETRY 기록 후 PAYMENT_PG_REFUND_FAILED
+ */
+@SpringBootTest
+@Transactional
+@TestPropertySource(properties = {
+        "spring.data.elasticsearch.repositories.enabled=false",
+        "feature.kafka.enabled=false"
+})
+class PaymentCancelIntegrationTest {
+
+    @MockitoBean
+    private com.google.firebase.messaging.FirebaseMessaging firebaseMessaging;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.search.adapter.in.event.AuctionItemIndexEventListener auctionItemIndexEventListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.ElasticsearchAuctionItemIndexingHandler elasticsearchAuctionItemIndexingHandler;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.payment.adapter.in.kafka.PaymentKafkaListener paymentKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.payment.adapter.in.kafka.PaymentUserKafkaListener paymentUserKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.payment.adapter.in.kafka.PaymentSettlementKafkaListener paymentSettlementKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.watchList.adapter.in.kafka.WatchListUserKafkaListener watchListUserKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.settlement.adapter.in.kafka.SettlementUserKafkaListener settlementUserKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.notification.adapter.in.kafka.NotificationUserKafkaListener notificationUserKafkaListener;
+
+    @MockitoBean
+    private PaymentGatewayPort paymentGatewayPort;
+
+    @MockitoSpyBean
+    private PaymentRefundRetryRecorder paymentRefundRetryRecorder;
+
+    @Autowired
+    private PaymentCancelUseCase paymentCancelUseCase;
+    @Autowired
+    private PaymentUserRepository paymentUserRepository;
+    @Autowired
+    private WalletRepository walletRepository;
+    @Autowired
+    private PaymentRepository paymentRepository;
+    @Autowired
+    private RefundRepository refundRepository;
+
+    private PaymentUser systemUser;
+    private PaymentUser customerUser;
+    private static final String ORDER_ID = "cancel-test-order-001";
+    private static final Long AUCTION_ORDER_ID = 300L;
+    private static final Long PAYMENT_AMOUNT = 20_000L;
+    private static final String PAYMENT_KEY = "cancel-test-payment-key";
+
+    @BeforeEach
+    void setUp() {
+        LocalDateTime now = LocalDateTime.now();
+        systemUser = paymentUserRepository.findByEmail(CashPolicy.SYSTEM_HOLDING_USER_EMAIL)
+                .orElseGet(() -> paymentUserRepository.save(
+                        PaymentUser.builder()
+                                .id(1L)
+                                .email(CashPolicy.SYSTEM_HOLDING_USER_EMAIL)
+                                .nickname("system-holding")
+                                .password("")
+                                .phoneNumber("")
+                                .createdAt(now)
+                                .updatedAt(now)
+                                .deletedAt(null)
+                                .status("ACTIVE")
+                                .build()));
+        customerUser = paymentUserRepository.findByEmail("cancel-test@test.com")
+                .orElseGet(() -> paymentUserRepository.save(
+                        PaymentUser.builder()
+                                .id(10L)
+                                .email("cancel-test@test.com")
+                                .nickname("cancel-customer")
+                                .password("")
+                                .phoneNumber("")
+                                .createdAt(now)
+                                .updatedAt(now)
+                                .deletedAt(null)
+                                .status("ACTIVE")
+                                .build()));
+
+        // 시스템 지갑: 취소 시 출금할 잔액 확보 (없으면 생성, 있으면 잔액 부족 시 credit으로 채움)
+        Wallet sysWallet = walletRepository.findWalletByPaymentUser(systemUser)
+                .orElseGet(() -> walletRepository.save(Wallet.builder().paymentUser(systemUser).balance(0L).build()));
+        if (sysWallet.getBalance() < 50_000L) {
+            sysWallet.credit(50_000L - sysWallet.getBalance(), CashEventType.임시보관__주문결제, "test", 1L);
+            walletRepository.saveAndFlush(sysWallet);
+        }
+        walletRepository.findWalletByPaymentUser(customerUser)
+                .orElseGet(() -> walletRepository.save(Wallet.builder().paymentUser(customerUser).balance(0L).build()));
+
+        refundRepository.deleteAll();
+        paymentRepository.deleteAll();
+    }
+
+    private OrderDto orderDto() {
+        return OrderDto.builder()
+                .orderId(ORDER_ID)
+                .auctionOrderId(AUCTION_ORDER_ID)
+                .price(PAYMENT_AMOUNT)
+                .userId(customerUser.getId())
+                .build();
+    }
+
+    private Payment createApprovedPayment() {
+        Payment payment = paymentRepository.saveAndFlush(
+                Payment.builder()
+                        .paymentKey(PAYMENT_KEY)
+                        .orderId(ORDER_ID)
+                        .auctionOrderId(AUCTION_ORDER_ID)
+                        .paymentUser(customerUser)
+                        .amount(PAYMENT_AMOUNT)
+                        .pgPaymentAmount(PAYMENT_AMOUNT)
+                        .status(PaymentStatus.APPROVED)
+                        .build());
+        return payment;
+    }
+
+    @Test
+    @DisplayName("[P-S4] 결제 취소 성공: PG cancel 성공 → 지갑 복원, Refund 저장")
+    void cancelPayment_success_refundCreatedAndWalletRestored() {
+        createApprovedPayment();
+        when(paymentGatewayPort.cancel(eq(PAYMENT_KEY), anyString(), eq(PAYMENT_AMOUNT)))
+                .thenReturn(PaymentExecutionResult.success(PAYMENT_KEY, ORDER_ID, PAYMENT_AMOUNT));
+
+        Refund refund = paymentCancelUseCase.cancelPayment("고객 요청", null, orderDto());
+
+        assertThat(refund).isNotNull();
+        assertThat(refund.getCancelAmount()).isEqualTo(PAYMENT_AMOUNT);
+        List<Refund> list = refundRepository.findRefundsByPayment_PaymentUser_Id(customerUser.getId());
+        assertThat(list).hasSize(1);
+
+        Payment after = paymentRepository.findPaymentByOrderId(ORDER_ID).orElseThrow();
+        assertThat(after.getStatus()).isEqualTo(PaymentStatus.CANCELED);
+        assertThat(after.getBalanceAmount()).isZero();
+
+        verify(paymentGatewayPort, times(1)).cancel(eq(PAYMENT_KEY), eq("고객 요청"), eq(PAYMENT_AMOUNT));
+    }
+
+    @Test
+    @DisplayName("[P-F10] 취소 요청 금액이 취소 가능 잔액 초과 시 PAYMENT_CANCEL_AMOUNT_EXCEEDS_BALANCE")
+    void cancelPayment_amountExceedsBalance_throws() {
+        createApprovedPayment();
+        Long overAmount = PAYMENT_AMOUNT + 5_000L;
+
+        assertThatThrownBy(() -> paymentCancelUseCase.cancelPayment("부분취소", overAmount, orderDto()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.PAYMENT_CANCEL_AMOUNT_EXCEEDS_BALANCE);
+                });
+
+        verify(paymentGatewayPort, never()).cancel(anyString(), anyString(), any());
+    }
+
+    @Test
+    @DisplayName("[P-S5] PG 취소 실패 시 recordRefundPgRetry 호출 후 PAYMENT_PG_REFUND_FAILED")
+    void cancelPayment_pgCancelFails_recordsRetryAndThrows() {
+        createApprovedPayment();
+        when(paymentGatewayPort.cancel(eq(PAYMENT_KEY), anyString(), eq(PAYMENT_AMOUNT)))
+                .thenThrow(new RuntimeException("PG timeout"));
+
+        assertThatThrownBy(() -> paymentCancelUseCase.cancelPayment("고객 요청", null, orderDto()))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.PAYMENT_PG_REFUND_FAILED);
+                });
+
+        verify(paymentGatewayPort, times(1)).cancel(eq(PAYMENT_KEY), anyString(), eq(PAYMENT_AMOUNT));
+        verify(paymentRefundRetryRecorder, times(1)).recordRefundPgRetry(eq(PAYMENT_KEY), eq(ORDER_ID), eq(PAYMENT_AMOUNT), anyString());
+    }
+}

--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/payment/application/service/PaymentConfirmFailureScenariosTest.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/payment/application/service/PaymentConfirmFailureScenariosTest.java
@@ -1,0 +1,154 @@
+package com.fourtune.auction.boundedContext.payment.application.service;
+
+import com.fourtune.auction.boundedContext.payment.port.out.AuctionPort;
+import com.fourtune.auction.boundedContext.payment.port.out.PaymentGatewayPort;
+import com.fourtune.core.error.ErrorCode;
+import com.fourtune.core.error.exception.BusinessException;
+import com.fourtune.shared.payment.dto.OrderDto;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * 결제 승인 실패 시나리오 (문서 P-F1, P-F3, P-F4)
+ * - P-F1: 주문 없음 / 주문자·결제자 불일치
+ * - P-F3: 주문 상태 비 PENDING
+ * - P-F4: 결제 금액 불일치
+ */
+@SpringBootTest
+@Transactional
+@TestPropertySource(properties = {
+        "spring.data.elasticsearch.repositories.enabled=false",
+        "feature.kafka.enabled=false"
+})
+class PaymentConfirmFailureScenariosTest {
+
+    @MockitoBean
+    private com.google.firebase.messaging.FirebaseMessaging firebaseMessaging;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.search.adapter.in.event.AuctionItemIndexEventListener auctionItemIndexEventListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.ElasticsearchAuctionItemIndexingHandler elasticsearchAuctionItemIndexingHandler;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.payment.adapter.in.kafka.PaymentKafkaListener paymentKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.payment.adapter.in.kafka.PaymentUserKafkaListener paymentUserKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.payment.adapter.in.kafka.PaymentSettlementKafkaListener paymentSettlementKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.watchList.adapter.in.kafka.WatchListUserKafkaListener watchListUserKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.settlement.adapter.in.kafka.SettlementUserKafkaListener settlementUserKafkaListener;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.notification.adapter.in.kafka.NotificationUserKafkaListener notificationUserKafkaListener;
+
+    @MockitoBean
+    private PaymentGatewayPort paymentGatewayPort;
+    @MockitoBean
+    private AuctionPort auctionPort;
+
+    @Autowired
+    private PaymentConfirmUseCase paymentConfirmUseCase;
+
+    private static final String ORDER_ID = "fail-scenario-order-001";
+    private static final String PAYMENT_KEY = "fail-payment-key-001";
+    private static final Long PG_AMOUNT = 10_000L;
+    private static final Long USER_ID = 1L;
+
+    @Test
+    @DisplayName("[P-F1] 주문 없음: getOrder null 시 PAYMENT_AUCTION_ORDER_NOT_FOUND")
+    void confirmPayment_orderNotFound_throwsAuctionOrderNotFound() {
+        when(paymentGatewayPort.confirm(eq(PAYMENT_KEY), eq(ORDER_ID), eq(PG_AMOUNT)))
+                .thenReturn(com.fourtune.auction.boundedContext.payment.domain.vo.PaymentExecutionResult.success(PAYMENT_KEY, ORDER_ID, PG_AMOUNT));
+        when(auctionPort.getOrder(eq(ORDER_ID))).thenReturn(null);
+
+        assertThatThrownBy(() -> paymentConfirmUseCase.confirmPayment(PAYMENT_KEY, ORDER_ID, PG_AMOUNT, USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.PAYMENT_AUCTION_ORDER_NOT_FOUND);
+                });
+
+        verify(paymentGatewayPort).confirm(anyString(), anyString(), anyLong());
+        verify(auctionPort).getOrder(eq(ORDER_ID));
+    }
+
+    @Test
+    @DisplayName("[P-F1] 주문자·결제자 불일치: userId 다르면 PAYMENT_PURCHASE_NOT_ALLOWED")
+    void confirmPayment_userMismatch_throwsPurchaseNotAllowed() {
+        when(paymentGatewayPort.confirm(eq(PAYMENT_KEY), eq(ORDER_ID), eq(PG_AMOUNT)))
+                .thenReturn(com.fourtune.auction.boundedContext.payment.domain.vo.PaymentExecutionResult.success(PAYMENT_KEY, ORDER_ID, PG_AMOUNT));
+        OrderDto orderDto = OrderDto.builder()
+                .orderId(ORDER_ID)
+                .auctionOrderId(100L)
+                .price(PG_AMOUNT)
+                .userId(999L)
+                .orderStatus("PENDING")
+                .build();
+        when(auctionPort.getOrder(eq(ORDER_ID))).thenReturn(orderDto);
+
+        assertThatThrownBy(() -> paymentConfirmUseCase.confirmPayment(PAYMENT_KEY, ORDER_ID, PG_AMOUNT, USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.PAYMENT_PURCHASE_NOT_ALLOWED);
+                });
+    }
+
+    @Test
+    @DisplayName("[P-F3] 주문 상태 비 PENDING: PAYMENT_ORDER_NOT_PENDING")
+    void confirmPayment_orderNotPending_throwsOrderNotPending() {
+        when(paymentGatewayPort.confirm(eq(PAYMENT_KEY), eq(ORDER_ID), eq(PG_AMOUNT)))
+                .thenReturn(com.fourtune.auction.boundedContext.payment.domain.vo.PaymentExecutionResult.success(PAYMENT_KEY, ORDER_ID, PG_AMOUNT));
+        OrderDto orderDto = OrderDto.builder()
+                .orderId(ORDER_ID)
+                .auctionOrderId(100L)
+                .price(PG_AMOUNT)
+                .userId(USER_ID)
+                .orderStatus("COMPLETED")
+                .build();
+        when(auctionPort.getOrder(eq(ORDER_ID))).thenReturn(orderDto);
+
+        assertThatThrownBy(() -> paymentConfirmUseCase.confirmPayment(PAYMENT_KEY, ORDER_ID, PG_AMOUNT, USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.PAYMENT_ORDER_NOT_PENDING);
+                });
+    }
+
+    @Test
+    @DisplayName("[P-F4] 결제 금액 불일치: pgAmount != order.price 시 PAYMENT_AMOUNT_MISMATCH")
+    void confirmPayment_amountMismatch_throwsAmountMismatch() {
+        when(paymentGatewayPort.confirm(eq(PAYMENT_KEY), eq(ORDER_ID), eq(PG_AMOUNT)))
+                .thenReturn(com.fourtune.auction.boundedContext.payment.domain.vo.PaymentExecutionResult.success(PAYMENT_KEY, ORDER_ID, PG_AMOUNT));
+        OrderDto orderDto = OrderDto.builder()
+                .orderId(ORDER_ID)
+                .auctionOrderId(100L)
+                .price(15_000L)
+                .userId(USER_ID)
+                .orderStatus("PENDING")
+                .build();
+        when(auctionPort.getOrder(eq(ORDER_ID))).thenReturn(orderDto);
+
+        assertThatThrownBy(() -> paymentConfirmUseCase.confirmPayment(PAYMENT_KEY, ORDER_ID, PG_AMOUNT, USER_ID))
+                .isInstanceOf(BusinessException.class)
+                .satisfies(ex -> {
+                    BusinessException be = (BusinessException) ex;
+                    assertThat(be.getErrorCode()).isEqualTo(ErrorCode.PAYMENT_AMOUNT_MISMATCH);
+                });
+
+        verify(auctionPort).getOrder(eq(ORDER_ID));
+        // 내부 로직 실패(금액 불일치 포함) 시 보상으로 cancel() 1회 호출됨
+        verify(paymentGatewayPort, times(1)).cancel(eq(PAYMENT_KEY), startsWith("System Logic Failed:"), eq(null));
+    }
+}


### PR DESCRIPTION
## 📌 개요
- 경매 사이트 전체 플로우(주문 → 결제 → 정산)와 기획 시나리오를 검증하기 위한 **통합 테스트 환경**을 보강했습니다.
- 결제·정산 도메인 시나리오 문서에 맞춰 테스트가 매핑되도록 정리하고, 실행 가능한 테스트 스위트와 실행 방법을 문서에 반영했습니다.

## 👩‍💻 작업 사항
- [x] **AuctionToSettlementFullFlowIntegrationTest** 추가: 주문(OrderDto 스텁) → 결제 승인 → 결제 완료 플로우 통합 테스트
- [x] **PaymentCancelIntegrationTest** 수정: 시스템 지갑 세팅을 삭제·재생성 대신 `credit()` 보충 방식으로 변경 (P-S4 안정화)
- [x] **PAYMENT_SETTLEMENT_AUCTION_TEST_SCENARIOS.md** 업데이트: 신규 테스트 클래스 표 추가, 결제·정산·전체플로우 시나리오 통합 테스트 실행 명령 추가
- [x] 결제·정산·통합 테스트 전체 실행 후 통과 확인

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
