### PR TITLE
payment 서비스 전용 DB(payment_db) 분리

### DIFF
--- a/fourtune/docker-compose.dev.yml
+++ b/fourtune/docker-compose.dev.yml
@@ -170,7 +170,7 @@ services:
     container_name: payment-service-dev
     environment:
       - SPRING_PROFILES_ACTIVE=dev
-      - DB_URL=jdbc:postgresql://postgres:5432/${DB_NAME:-fourtune_db}
+      - DB_URL=jdbc:postgresql://postgres:5432/payment_db
       - DB_USERNAME=${DB_USERNAME:-fourtune_user}
       - DB_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=redis

--- a/fourtune/docker-compose.prod.yml
+++ b/fourtune/docker-compose.prod.yml
@@ -168,7 +168,7 @@ services:
       - .env
     environment:
       - SPRING_PROFILES_ACTIVE=prod
-      - DB_URL=jdbc:postgresql://postgres:5432/${DB_NAME:-fourtune_db}
+      - DB_URL=jdbc:postgresql://postgres:5432/payment_db
       - DB_USERNAME=${DB_USERNAME}
       - DB_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=redis

--- a/fourtune/docker-compose.yml
+++ b/fourtune/docker-compose.yml
@@ -191,8 +191,8 @@ services:
     # ... (기존 build, image 설정)
     environment:
       - SPRING_PROFILES_ACTIVE=local
-      # 결제 서비스 전용 DB (같은 DB를 쓴다면 동일하게, 분리했다면 해당 주소로)
-      - DB_URL=jdbc:postgresql://postgres:5432/fourtune_db
+      # 결제 서비스 전용 DB (서비스별 DB 분리)
+      - DB_URL=jdbc:postgresql://postgres:5432/payment_db
       - DB_USERNAME=fourtune_user
       - DB_PASSWORD=fourtune
       # Redis (결제 임시 데이터나 멱등성 체크용)

--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/payment/adapter/in/web/PaymentController.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/payment/adapter/in/web/PaymentController.java
@@ -2,7 +2,6 @@ package com.fourtune.auction.boundedContext.payment.adapter.in.web;
 
 import com.fourtune.auction.boundedContext.payment.adapter.in.web.dto.ConfirmPaymentRequest;
 import com.fourtune.auction.boundedContext.payment.adapter.in.web.dto.WalletResponse;
-import com.fourtune.auction.boundedContext.payment.application.service.PaymentCancelUseCase;
 import com.fourtune.auction.boundedContext.payment.application.service.PaymentFacade;
 import com.fourtune.auction.boundedContext.payment.domain.entity.CashLog;
 import com.fourtune.auction.boundedContext.payment.domain.entity.Payment;
@@ -24,7 +23,6 @@ import java.util.List;
 @RequestMapping("/api/payments")
 public class PaymentController {
     private final PaymentFacade paymentFacade;
-    private final PaymentCancelUseCase paymentCancelUseCase;
     /**
       * 토스페이먼츠 성공 리다이렉트가 아래와 같음
       * URL 예시: /api/payments/toss/success?paymentKey=...&orderId=...&amount=...

--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/payment/application/service/PaymentFacade.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/payment/application/service/PaymentFacade.java
@@ -3,6 +3,7 @@ package com.fourtune.auction.boundedContext.payment.application.service;
 import com.fourtune.auction.boundedContext.payment.domain.entity.*;
 import com.fourtune.auction.boundedContext.payment.domain.vo.PaymentExecutionResult;
 import com.fourtune.auction.boundedContext.payment.port.out.CashLogRepository;
+import com.fourtune.shared.payment.dto.OrderDto;
 import com.fourtune.shared.payment.dto.PaymentUserDto;
 import com.fourtune.shared.settlement.dto.SettlementDto;
 import com.fourtune.shared.user.dto.UserResponse;
@@ -103,5 +104,13 @@ public class PaymentFacade {
     @Transactional
     public void deleteUser(UserResponse user) {
         paymentSupport.deleteUser(user);
+    }
+
+    /**
+     * 결제 취소(환불). 외부(주문/경매)에서 OrderDto 확보 후 호출.
+     */
+    @Transactional
+    public Refund cancelPayment(String cancelReason, Long cancelAmount, OrderDto orderDto) {
+        return paymentCancelUseCase.cancelPayment(cancelReason, cancelAmount, orderDto);
     }
 }

--- a/fourtune/init-db/03-create-payment-db.sh
+++ b/fourtune/init-db/03-create-payment-db.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+set -e
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "postgres" -c "CREATE DATABASE payment_db;"

--- a/fourtune/payment-service/src/main/resources/application.yml
+++ b/fourtune/payment-service/src/main/resources/application.yml
@@ -13,7 +13,7 @@ spring:
       on-profile: local
 
   datasource:
-    url: ${DB_URL:jdbc:postgresql://localhost:5432/fourtune_db}
+    url: ${DB_URL:jdbc:postgresql://localhost:5432/payment_db}
     username: ${DB_USERNAME:fourtune_user}
     password: ${DB_PASSWORD:fourtune}
     driver-class-name: org.postgresql.Driver


### PR DESCRIPTION
## 📌 개요
- payment 서비스를 다른 서비스(auction, recommendation)처럼 **전용 DB**를 쓰도록 분리하기 위함
- 기존에는 payment-service도 fourtune_db를 참조할 수 있었으나, MSA 관점에서 결제 데이터를 payment 전용 DB로 분리해 운영·확장성을 높이기 위한 작업

## 👩‍💻 작업 사항
- [x] `init-db/03-create-payment-db.sh` 추가 — PostgreSQL 최초 기동 시 `payment_db` 생성
- [x] payment-service `application.yml` — datasource 기본값을 `payment_db`로 설정
- [x] `docker-compose.yml` — payment-service 환경변수 `DB_URL`을 `payment_db`로 설정
- [x] `docker-compose.dev.yml` / `docker-compose.prod.yml` — payment-service의 `DB_URL`을 `payment_db`로 유지·확인
- [x] fourtune-api는 기존처럼 `fourtune_db`만 사용하도록 유지

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
