### PR TITLE
feat: payment·recommendation·auction 라우팅 추가

### DIFF
--- a/fourtune/docker-compose.dev.yml
+++ b/fourtune/docker-compose.dev.yml
@@ -170,6 +170,7 @@ services:
     container_name: payment-service-dev
     environment:
       - SPRING_PROFILES_ACTIVE=dev
+      - SERVER_PORT=8080
       - DB_URL=jdbc:postgresql://postgres:5432/payment_db
       - DB_USERNAME=${DB_USERNAME:-fourtune_user}
       - DB_PASSWORD=${DB_PASSWORD}

--- a/fourtune/docker-compose.prod.yml
+++ b/fourtune/docker-compose.prod.yml
@@ -168,6 +168,7 @@ services:
       - .env
     environment:
       - SPRING_PROFILES_ACTIVE=prod
+      - SERVER_PORT=8080
       - DB_URL=jdbc:postgresql://postgres:5432/payment_db
       - DB_USERNAME=${DB_USERNAME}
       - DB_PASSWORD=${DB_PASSWORD}

--- a/fourtune/nginx/nginx.dev.conf
+++ b/fourtune/nginx/nginx.dev.conf
@@ -34,9 +34,24 @@ http {
     # Rate limiting (개발 서버용 - 느슨함)
     limit_req_zone $binary_remote_addr zone=api_limit:10m rate=50r/s;
 
-    # Upstream backend
+    # Upstream: 메인 API (fourtune-api)
     upstream backend {
         server app:8080 max_fails=3 fail_timeout=30s;
+    }
+
+    # Upstream: 결제 서비스 (payment-service)
+    upstream payment {
+        server payment-service:8080 max_fails=3 fail_timeout=30s;
+    }
+
+    # Upstream: 추천 서비스 (recommendation-service)
+    upstream recommendation {
+        server recommendation-service:8084 max_fails=3 fail_timeout=30s;
+    }
+
+    # Upstream: 경매 서비스 (auction-service, compose에 포함 시 사용)
+    upstream auction {
+        server auction-service:8083 max_fails=3 fail_timeout=30s;
     }
 
     # HTTP Server (개발 서버 - HTTP만)
@@ -44,7 +59,7 @@ http {
         listen 80;
         server_name _;  # 모든 도메인 허용
 
-        # OAuth2 authorization (소셜 로그인 시작)
+        # OAuth2 authorization (소셜 로그인 시작) — #313
         location /oauth2/ {
             proxy_pass http://backend;
             proxy_http_version 1.1;
@@ -64,17 +79,93 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # API endpoints
+        # 결제 API → payment-service
+        location /api/payments {
+            limit_req zone=api_limit burst=100 nodelay;
+            proxy_pass http://payment;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+
+        # 추천 API → recommendation-service
+        location /api/v1/recommendations {
+            limit_req zone=api_limit burst=100 nodelay;
+            proxy_pass http://recommendation;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+
+        # 경매 API → auction-service
+        location /api/v1/auctions {
+            limit_req zone=api_limit burst=100 nodelay;
+            proxy_pass http://auction;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+        location /api/v1/orders {
+            limit_req zone=api_limit burst=100 nodelay;
+            proxy_pass http://auction;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+        location /api/v1/bids {
+            limit_req zone=api_limit burst=100 nodelay;
+            proxy_pass http://auction;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+        location /api/v1/cart {
+            limit_req zone=api_limit burst=100 nodelay;
+            proxy_pass http://auction;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+
+        # 그 외 API → fourtune-api (app)
         location /api/ {
             limit_req zone=api_limit burst=100 nodelay;
-            
             proxy_pass http://backend;
             proxy_http_version 1.1;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            
             proxy_connect_timeout 60s;
             proxy_send_timeout 60s;
             proxy_read_timeout 60s;

--- a/fourtune/nginx/nginx.prod.conf
+++ b/fourtune/nginx/nginx.prod.conf
@@ -39,10 +39,28 @@ http {
     limit_req_zone $binary_remote_addr zone=api_limit:10m rate=10r/s;
     limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=5r/s;
 
-    # Upstream backend servers
+    # Upstream: 메인 API (fourtune-api)
     upstream backend {
         least_conn;
         server app:8080 max_fails=3 fail_timeout=30s;
+    }
+
+    # Upstream: 결제 서비스 (payment-service)
+    upstream payment {
+        least_conn;
+        server payment-service:8080 max_fails=3 fail_timeout=30s;
+    }
+
+    # Upstream: 추천 서비스 (recommendation-service)
+    upstream recommendation {
+        least_conn;
+        server recommendation-service:8084 max_fails=3 fail_timeout=30s;
+    }
+
+    # Upstream: 경매 서비스 (auction-service, compose에 포함 시 사용)
+    upstream auction {
+        least_conn;
+        server auction-service:8083 max_fails=3 fail_timeout=30s;
     }
 
     # 1. HTTP Server (80 Port) -> HTTPS로 강제 리다이렉트
@@ -91,7 +109,7 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # OAuth2 authorization (소셜 로그인 시작)
+        # OAuth2 authorization (소셜 로그인 시작) — #313
         location /oauth2/ {
             proxy_pass http://backend;
             proxy_set_header Host $host;
@@ -109,7 +127,85 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
-        # API endpoints
+        # 결제 API → payment-service
+        location /api/payments {
+            limit_req zone=api_limit burst=20 nodelay;
+            proxy_pass http://payment;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+
+        # 추천 API → recommendation-service
+        location /api/v1/recommendations {
+            limit_req zone=api_limit burst=20 nodelay;
+            proxy_pass http://recommendation;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+
+        # 경매 API → auction-service
+        location /api/v1/auctions {
+            limit_req zone=api_limit burst=20 nodelay;
+            proxy_pass http://auction;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+        location /api/v1/orders {
+            limit_req zone=api_limit burst=20 nodelay;
+            proxy_pass http://auction;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+        location /api/v1/bids {
+            limit_req zone=api_limit burst=20 nodelay;
+            proxy_pass http://auction;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+        location /api/v1/cart {
+            limit_req zone=api_limit burst=20 nodelay;
+            proxy_pass http://auction;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_connect_timeout 60s;
+            proxy_send_timeout 60s;
+            proxy_read_timeout 60s;
+        }
+
+        # 그 외 API → fourtune-api
         location /api/ {
             limit_req zone=api_limit burst=20 nodelay;
             proxy_pass http://backend;


### PR DESCRIPTION
## 📌 개요
- Nginx에서 결제·추천·경매 API를 각 전용 서비스로 라우팅하도록 MSA 라우팅을 추가
- 원격에 먼저 반영된 OAuth2 location(#313)은 유지하고, payment / recommendation / auction upstream·location을 추가해 프론트엔드가 단일 진입점(80/443)으로 모든 API를 호출할 수 있게 함
- payment-service는 application 기본 포트가 8081이라, Docker 내부에서 Nginx upstream(8080)과 맞추기 위해 compose에 `SERVER_PORT=8080`을 추가

## 👩‍💻 작업 사항
- [x] nginx.dev.conf: payment / recommendation / auction upstream 및 location 추가, OAuth2(/oauth2/, /login/oauth2/) 유지
- [x] nginx.prod.conf: 동일 MSA 라우팅 및 OAuth2 유지 (http2 설정 포함)
- [x] docker-compose.dev.yml: payment-service 환경변수에 `SERVER_PORT=8080` 추가
- [x] docker-compose.prod.yml: payment-service 환경변수에 `SERVER_PORT=8080` 추가

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
