### PR TITLE
fix: Outbox 발행 버그 수정 및 fourtune-api Payment Outbox 핸들러 추가

### DIFF
--- a/fourtune/fourtune-api/src/main/java/com/fourtune/api/infrastructure/kafka/payment/PaymentEventPayload.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/api/infrastructure/kafka/payment/PaymentEventPayload.java
@@ -1,0 +1,21 @@
+package com.fourtune.api.infrastructure.kafka.payment;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 결제 Outbox payload 래퍼
+ * UseCase에서 append 시 Map으로 이 구조를 저장하고, Handler에서 payload 문자열만 받아 역직렬화할 때 사용
+ * aggregateId는 결제 성공 시 payment.getId()(Long), 실패/재시도 시 orderId(String) 또는 0L 등 혼용되므로 Object로 수용
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PaymentEventPayload {
+
+    private String eventType;
+    private Object aggregateId;  // Long(paymentId) 또는 String(orderId) 혼용
+    private JsonNode data;
+}

--- a/fourtune/fourtune-api/src/main/java/com/fourtune/api/infrastructure/kafka/payment/PaymentKafkaProducer.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/api/infrastructure/kafka/payment/PaymentKafkaProducer.java
@@ -1,0 +1,56 @@
+package com.fourtune.api.infrastructure.kafka.payment;
+
+import com.fourtune.kafka.KafkaTopicConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * 결제 이벤트 Kafka Producer (fourtune-api)
+ * payment-events 토픽으로 발행. Outbox 발행은 fourtune_db에 쌓인 Payment 이벤트를 전송할 때 사용
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "feature.kafka.enabled", havingValue = "true", matchIfMissing = false)
+public class PaymentKafkaProducer {
+
+    private static final String HEADER_EVENT_TYPE = "X-Event-Type";
+
+    private final KafkaTemplate<String, String> auctionKafkaTemplate;
+
+    public CompletableFuture<?> send(String key, String payload, String eventType) {
+        Message<String> message = MessageBuilder
+                .withPayload(payload)
+                .setHeader(KafkaHeaders.TOPIC, KafkaTopicConfig.PAYMENT_EVENTS_TOPIC)
+                .setHeader(KafkaHeaders.KEY, key)
+                .setHeader(HEADER_EVENT_TYPE, eventType)
+                .build();
+        return auctionKafkaTemplate.send(message)
+                .whenComplete((result, ex) -> {
+                    if (ex == null) {
+                        log.debug("Payment 이벤트 발행 성공: topic={}, key={}, eventType={}",
+                                KafkaTopicConfig.PAYMENT_EVENTS_TOPIC, key, eventType);
+                    } else {
+                        log.error("Payment 이벤트 발행 실패: topic={}, key={}, eventType={}, error={}",
+                                KafkaTopicConfig.PAYMENT_EVENTS_TOPIC, key, eventType, ex.getMessage(), ex);
+                    }
+                });
+    }
+
+    public void sendSync(String key, String payload, String eventType) {
+        try {
+            send(key, payload, eventType).get();
+        } catch (Exception e) {
+            log.error("Payment 이벤트 동기 발행 실패: key={}, eventType={}", key, eventType, e);
+            throw new RuntimeException("Payment Kafka 메시지 발행 실패", e);
+        }
+    }
+}

--- a/fourtune/fourtune-api/src/main/java/com/fourtune/api/infrastructure/kafka/payment/PaymentOutboxEventHandler.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/api/infrastructure/kafka/payment/PaymentOutboxEventHandler.java
@@ -1,0 +1,38 @@
+package com.fourtune.api.infrastructure.kafka.payment;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fourtune.outbox.handler.OutboxEventHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * 결제 도메인 Outbox 이벤트 핸들러 (fourtune-api)
+ * fourtune_db에 쌓인 Payment Outbox를 payment-events 토픽으로 발행
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "feature.kafka.enabled", havingValue = "true", matchIfMissing = false)
+public class PaymentOutboxEventHandler implements OutboxEventHandler {
+
+    private static final String AGGREGATE_TYPE = "Payment";
+
+    private final PaymentKafkaProducer paymentKafkaProducer;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public String getAggregateType() {
+        return AGGREGATE_TYPE;
+    }
+
+    @Override
+    public void handle(String payload) throws Exception {
+        PaymentEventPayload wrapper = objectMapper.readValue(payload, PaymentEventPayload.class);
+        String key = String.valueOf(wrapper.getAggregateId());
+        String eventType = wrapper.getEventType();
+        String value = objectMapper.writeValueAsString(wrapper.getData());
+        paymentKafkaProducer.sendSync(key, value, eventType);
+    }
+}

--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/payment/application/service/PaymentRefundRetryRecorder.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/payment/application/service/PaymentRefundRetryRecorder.java
@@ -27,6 +27,6 @@ public class PaymentRefundRetryRecorder {
     public void recordRefundPgRetry(String paymentKey, String orderId, Long amount, String cancelReason) {
         log.warn("환불 PG 재시도 이벤트 기록: paymentKey={}, orderId={}, amount={}", paymentKey, orderId, amount);
         outboxService.append(AGGREGATE_TYPE_PAYMENT, 0L, EVENT_TYPE_REFUND_PG_RETRY,
-                Map.of("eventType", EVENT_TYPE_REFUND_PG_RETRY, "paymentKey", paymentKey, "orderId", orderId, "amount", amount, "cancelReason", cancelReason != null ? cancelReason : ""));
+                Map.of("eventType", EVENT_TYPE_REFUND_PG_RETRY, "aggregateId", 0L, "data", Map.of("paymentKey", paymentKey, "orderId", orderId, "amount", amount, "cancelReason", cancelReason != null ? cancelReason : "")));
     }
 }


### PR DESCRIPTION
## 📌 개요

- **Outbox 블랙홀**: 유저/경매 Kafka가 꺼져 있으면 결제·정산 Outbox까지 발행이 멈추던 하드코딩 버그 수정
- **Payment Outbox 미발행**: 결제 트래픽이 fourtune-api로만 오기 때문에, fourtune_db에 쌓인 Payment Outbox를 Kafka로 보내는 핸들러가 없어 이벤트가 발행되지 않던 문제 해결

## 👩‍💻 작업 사항

- [x] **OutboxPublisher**  
  - `publishPendingEvents()`, `retryFailedEvents()` 내부의 `userEventsKafkaEnabled && auctionEventsKafkaEnabled` 전용 early return 제거  
  - 미사용 `EventPublishingConfig` 의존성 제거
- [x] **fourtune-api Payment Outbox**  
  - `PaymentEventPayload` (eventType, aggregateId, data) 추가  
  - `PaymentKafkaProducer` (payment-events 토픽, auctionKafkaTemplate 사용) 추가  
  - `PaymentOutboxEventHandler` (aggregateType `"Payment"`) 추가
- [x] **Payload 계약 통일**  
  - `PaymentRefundRetryRecorder`: append 시 `eventType` / `aggregateId` / `data` 표준 형식으로 변경  
  - `PaymentEventPayload.aggregateId`: Long → Object (paymentId Long / orderId String 혼용 대응)

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
