### PR TITLE
Payment→Auction, Auction→Settlement Kafka 연동 및 DLQ 적용

### DIFF
--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/kafka/PaymentResultKafkaListener.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/kafka/PaymentResultKafkaListener.java
@@ -1,0 +1,72 @@
+package com.fourtune.auction.boundedContext.auction.adapter.in.kafka;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fourtune.auction.boundedContext.auction.application.service.OrderCompleteUseCase;
+import com.fourtune.kafka.KafkaTopicConfig;
+import com.fourtune.shared.payment.event.PaymentFailedEvent;
+import com.fourtune.shared.payment.event.PaymentSucceededEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.stereotype.Component;
+
+/**
+ * payment-events 토픽 구독 — 결제 완료/실패 시 주문 상태 반영 (MSA 분리 시 Payment → Auction 연동)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "feature.kafka.enabled", havingValue = "true", matchIfMissing = false)
+public class PaymentResultKafkaListener {
+
+    private static final String HEADER_EVENT_TYPE = "X-Event-Type";
+
+    private final ObjectMapper objectMapper;
+    private final OrderCompleteUseCase orderCompleteUseCase;
+
+    @KafkaListener(
+            topics = KafkaTopicConfig.PAYMENT_EVENTS_TOPIC,
+            groupId = "auction-payment-events-group",
+            containerFactory = "paymentEventKafkaListenerContainerFactory"
+    )
+    public void handlePaymentEvent(
+            @Payload String payload,
+            @Header(HEADER_EVENT_TYPE) String eventType,
+            @Header(KafkaHeaders.RECEIVED_KEY) String key
+    ) {
+        if (!"PAYMENT_SUCCEEDED".equals(eventType) && !"PAYMENT_FAILED".equals(eventType)) {
+            log.debug("Auction에서 무시하는 결제 이벤트: eventType={}", eventType);
+            return;
+        }
+
+        log.info("Payment 결과 수신(주문 반영): eventType={}, key={}", eventType, key);
+
+        try {
+            if ("PAYMENT_SUCCEEDED".equals(eventType)) {
+                PaymentSucceededEvent event = objectMapper.readValue(payload, PaymentSucceededEvent.class);
+                if (event.getOrder() != null && event.getOrder().getOrderId() != null) {
+                    orderCompleteUseCase.completePayment(event.getOrder().getOrderId(), "");
+                    log.info("주문 완료 처리 완료: orderId={}", event.getOrder().getOrderId());
+                } else {
+                    log.warn("PAYMENT_SUCCEEDED 수신했으나 order 정보 없음: key={}", key);
+                }
+            } else {
+                PaymentFailedEvent event = objectMapper.readValue(payload, PaymentFailedEvent.class);
+                if (event.getOrder() != null && event.getOrder().getOrderId() != null) {
+                    String reason = event.getMsg() != null ? event.getMsg() : "결제 실패";
+                    orderCompleteUseCase.failPayment(event.getOrder().getOrderId(), reason);
+                    log.info("주문 실패 처리 완료: orderId={}, reason={}", event.getOrder().getOrderId(), reason);
+                } else {
+                    log.warn("PAYMENT_FAILED 수신했으나 order 정보 없음: key={}", key);
+                }
+            }
+        } catch (Exception e) {
+            log.error("Payment 결과 처리 실패: eventType={}, key={}, error={}", eventType, key, e.getMessage(), e);
+            throw new RuntimeException("Payment 결과 처리 실패", e);
+        }
+    }
+}

--- a/fourtune/common/kafka/src/main/java/com/fourtune/kafka/KafkaConfig.java
+++ b/fourtune/common/kafka/src/main/java/com/fourtune/kafka/KafkaConfig.java
@@ -1,7 +1,9 @@
 package com.fourtune.kafka;
 
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -11,11 +13,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.*;
 import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.util.backoff.FixedBackOff;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiFunction;
 
 @Configuration
 @ConditionalOnProperty(name = "feature.kafka.enabled", havingValue = "true", matchIfMissing = false)
@@ -44,6 +48,21 @@ public class KafkaConfig {
         return new KafkaTemplate<>(producerFactory());
     }
 
+    /**
+     * 재시도 소진 시 실패 메시지를 원본 토픽명 + "-dlq" 토픽으로 전달 (메시지 유실 방지)
+     */
+    @Bean
+    public DeadLetterPublishingRecoverer deadLetterPublishingRecoverer(KafkaTemplate<String, String> kafkaTemplate) {
+        BiFunction<ConsumerRecord<?, ?>, Exception, TopicPartition> resolver =
+                (record, ex) -> new TopicPartition(record.topic() + "-dlq", record.partition());
+        return new DeadLetterPublishingRecoverer(kafkaTemplate, resolver);
+    }
+
+    @Bean
+    public DefaultErrorHandler kafkaCommonErrorHandler(DeadLetterPublishingRecoverer deadLetterPublishingRecoverer) {
+        return new DefaultErrorHandler(deadLetterPublishingRecoverer, new FixedBackOff(1000L, 3));
+    }
+
     // --- User Event Consumer 설정 (String 기반) ---
 
     @Bean
@@ -58,13 +77,14 @@ public class KafkaConfig {
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, String> userEventKafkaListenerContainerFactory(
-            ConsumerFactory<String, String> userEventConsumerFactory) {
+            ConsumerFactory<String, String> userEventConsumerFactory,
+            DefaultErrorHandler kafkaCommonErrorHandler) {
 
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(userEventConsumerFactory);
         factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
-        factory.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(1000L, 3)));
+        factory.setCommonErrorHandler(kafkaCommonErrorHandler);
         return factory;
     }
 
@@ -81,11 +101,12 @@ public class KafkaConfig {
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, String> auctionEventKafkaListenerContainerFactory(
-            ConsumerFactory<String, String> auctionEventConsumerFactory) {
+            ConsumerFactory<String, String> auctionEventConsumerFactory,
+            DefaultErrorHandler kafkaCommonErrorHandler) {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(auctionEventConsumerFactory);
-        factory.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(1000L, 3)));
+        factory.setCommonErrorHandler(kafkaCommonErrorHandler);
         return factory;
     }
 
@@ -102,11 +123,12 @@ public class KafkaConfig {
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, String> watchlistEventKafkaListenerContainerFactory(
-            ConsumerFactory<String, String> watchlistEventConsumerFactory) {
+            ConsumerFactory<String, String> watchlistEventConsumerFactory,
+            DefaultErrorHandler kafkaCommonErrorHandler) {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(watchlistEventConsumerFactory);
-        factory.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(1000L, 3)));
+        factory.setCommonErrorHandler(kafkaCommonErrorHandler);
         return factory;
     }
 
@@ -123,11 +145,12 @@ public class KafkaConfig {
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, String> paymentEventKafkaListenerContainerFactory(
-            ConsumerFactory<String, String> paymentEventConsumerFactory) {
+            ConsumerFactory<String, String> paymentEventConsumerFactory,
+            DefaultErrorHandler kafkaCommonErrorHandler) {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(paymentEventConsumerFactory);
-        factory.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(1000L, 3)));
+        factory.setCommonErrorHandler(kafkaCommonErrorHandler);
         return factory;
     }
 
@@ -144,11 +167,12 @@ public class KafkaConfig {
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, String> settlementEventKafkaListenerContainerFactory(
-            ConsumerFactory<String, String> settlementEventConsumerFactory) {
+            ConsumerFactory<String, String> settlementEventConsumerFactory,
+            DefaultErrorHandler kafkaCommonErrorHandler) {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(settlementEventConsumerFactory);
-        factory.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(1000L, 3)));
+        factory.setCommonErrorHandler(kafkaCommonErrorHandler);
         return factory;
     }
 
@@ -165,11 +189,12 @@ public class KafkaConfig {
 
     @Bean
     public ConcurrentKafkaListenerContainerFactory<String, String> notificationEventKafkaListenerContainerFactory(
-            ConsumerFactory<String, String> notificationEventConsumerFactory) {
+            ConsumerFactory<String, String> notificationEventConsumerFactory,
+            DefaultErrorHandler kafkaCommonErrorHandler) {
         ConcurrentKafkaListenerContainerFactory<String, String> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(notificationEventConsumerFactory);
-        factory.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(1000L, 3)));
+        factory.setCommonErrorHandler(kafkaCommonErrorHandler);
         return factory;
     }
 }

--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/settlement/adapter/in/kafka/SettlementAuctionKafkaListener.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/settlement/adapter/in/kafka/SettlementAuctionKafkaListener.java
@@ -1,4 +1,56 @@
 package com.fourtune.auction.boundedContext.settlement.adapter.in.kafka;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fourtune.auction.boundedContext.settlement.application.service.SettlementFacade;
+import com.fourtune.kafka.KafkaTopicConfig;
+import com.fourtune.shared.auction.event.OrderCompletedEvent;
+import com.fourtune.shared.kafka.auction.AuctionEventType;
+import com.fourtune.shared.payment.dto.OrderDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Component;
+
+/**
+ * auction-events 토픽 구독 — 주문 완료(ORDER_COMPLETED) 시 정산 후보 등록 (MSA 분리 시 Auction → Settlement 연동)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "feature.kafka.auction-events.enabled", havingValue = "true", matchIfMissing = false)
 public class SettlementAuctionKafkaListener {
+
+    private final ObjectMapper objectMapper;
+    private final SettlementFacade settlementFacade;
+
+    @KafkaListener(
+            topics = KafkaTopicConfig.AUCTION_EVENTS_TOPIC,
+            groupId = "settlement-auction-events-group",
+            containerFactory = "auctionEventKafkaListenerContainerFactory"
+    )
+    public void consume(String payload, @Header(value = "X-Event-Type", required = false) String eventType) {
+        if (eventType == null) {
+            return;
+        }
+
+        if (!AuctionEventType.ORDER_COMPLETED.name().equals(eventType)) {
+            log.trace("[Settlement] 무시하는 경매 이벤트: eventType={}", eventType);
+            return;
+        }
+
+        log.info("[Settlement] 주문 완료 이벤트 수신 → 정산 후보 등록: eventType={}", eventType);
+
+        try {
+            OrderCompletedEvent event = objectMapper.readValue(payload, OrderCompletedEvent.class);
+            OrderDto orderDto = OrderDto.from(event);
+            settlementFacade.addSettlementCandidatedItem(orderDto);
+            log.info("[Settlement] 정산 후보 등록 완료: orderId={}", event.orderId());
+        } catch (Exception e) {
+            log.error("[Settlement] ORDER_COMPLETED 처리 실패: eventType={}, payload={}, error={}",
+                    eventType, payload, e.getMessage(), e);
+            throw new RuntimeException("Settlement ORDER_COMPLETED 처리 실패", e);
+        }
+    }
 }


### PR DESCRIPTION
## 📌 개요
- MSA 분리 이슈 문서 6번(이벤트·Kafka 연동) 2순위 반영.
- **Payment → Auction**: 결제 완료/실패가 payment-events로만 전달되는 환경에서 auction-service가 주문 상태를 반영하도록 payment-events 구독 리스너 추가.
- **Auction → Settlement**: 주문 완료(ORDER_COMPLETED)가 auction-events로만 전달되는 환경에서 fourtune-api가 정산 후보를 등록하도록 SettlementAuctionKafkaListener 구현.
- **DLQ**: 3회 재시도 후에도 실패한 메시지가 유실되지 않도록 common/kafka에 DeadLetterPublishingRecoverer 적용, *-dlq 토픽으로 격리.

## 👩‍💻 작업 사항
- [x] auction-service: PaymentResultKafkaListener 추가 (payment-events, PAYMENT_SUCCEEDED/PAYMENT_FAILED → 주문 완료/실패 처리)
- [x] fourtune-api: SettlementAuctionKafkaListener 구현 (auction-events ORDER_COMPLETED → 정산 후보 등록)
- [x] common/kafka: DeadLetterPublishingRecoverer + kafkaCommonErrorHandler 빈 추가, 6개 ListenerContainerFactory에 DLQ 적용
- [x] docs/msa/2ND_PRIORITY_PLAN.md 구현 완료 내역 반영

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
