### PR TITLE
chore: s3 의존성 버전 3.0.1에서 4.0.0으로 변경하여 통일

### DIFF
--- a/fourtune/common/s3/build.gradle
+++ b/fourtune/common/s3/build.gradle
@@ -7,6 +7,6 @@ jar { enabled = true }
 
 dependencies {
     api project(':common:core')
-    api 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.0.1'
+    api 'io.awspring.cloud:spring-cloud-aws-starter-s3:4.0.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }


### PR DESCRIPTION
## 📌 개요
- 기존 common/s3 build.gradle의 s3 의존성이 3.x로 잘못 작성되어 있어, spring boot와 버전 충돌이 일어났습니다.
- common/s3에서의 s3의존성을 common에서의 의존성(정답)과 같은 4.0.0로 변경했습니다.

## 👩‍💻 작업 사항
- [x] common/s3 build.gradle의 io.awspring.cloud:spring-cloud-aws-starter-s3 버전을 3.0.1에서 4.0.0버전으로 변경

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #330 
