### PR TITLE
chore: 로컬 PostgreSQL과의 포트 충돌 방지를 위해 5433으로 변경

### DIFF
--- a/fourtune/docker-compose.yml
+++ b/fourtune/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       POSTGRES_USER: fourtune_user
       POSTGRES_PASSWORD: fourtune
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init-db:/docker-entrypoint-initdb.d


### PR DESCRIPTION
## 📌 개요
- 로컬 환경에서 PostgreSQL(5432 포트)이 이미 실행 중이어서, Docker PostgreSQL과 포트 충돌이 발생하였습니다. 따라서 로컬 Docker PostgreSQL의 포트 매핑을 다음과 같이 변경할 예정입니다.

기존: 5432:5432
변경: 5433:5432

컨테이너 간 통신(postgres:5432)은 기존과 동일하며, 외부 접속 시에는 5433 포트를 사용해야 합니다.

## 👩‍💻 작업 사항
- [x] docker-compose.yml(로컬 도커컴포스) 파일을 수정하여, 로컬 Docker PostgreSQL의 포트 매핑 5433:5432로 변경

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #335 
