### PR TITLE
chore: OpenFeign 5.x 업그레이드에 따른 Resilience4j 재시도 예외 클래스 명칭 수정

### DIFF
--- a/fourtune/fourtune-api/src/main/resources/application.yml
+++ b/fourtune/fourtune-api/src/main/resources/application.yml
@@ -113,7 +113,7 @@ resilience4j:
         retryExceptions:
           - java.net.ConnectException
           - java.io.IOException
-          - org.springframework.cloud.openfeign.FeignException
+          - feign.FeignException
 
 # application.yml
 settlement:

--- a/fourtune/payment-service/src/main/resources/application.yml
+++ b/fourtune/payment-service/src/main/resources/application.yml
@@ -30,7 +30,7 @@ resilience4j:
         retryExceptions:
           - java.net.ConnectException
           - java.io.IOException
-          - org.springframework.cloud.openfeign.FeignException
+          - feign.FeignException
 
 spring:
   profiles:


### PR DESCRIPTION
## 📌 개요
- 3일 전에 OpenFeign 버전을 5.0.1로 업그레이드한 이후(#297 ) Spring Boot(fourtune-api, payment-service) 기동 시 ClassNotFoundException이 발생하며 뻗는 문제를 해결했습니다. 
- 원인은 Resilience4j 설정에 등록된 org.springframework.cloud.openfeign.FeignException 클래스가 최신 버전에서 제거되었기 때문입니다.

## 👩‍💻 작업 사항
- [x] fourtune-api 내의 application.yml 파일 내 retry exceptions 클래스를 feign.FeignException으로 변경 
- [x] payment-service 내의 application.yml 파일 내 retry exceptions 클래스를 feign.FeignException으로 변경

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
