### PR TITLE
fix: payment-service JWT 설정 추가 및 도커 기동 시 기본값 보완

### DIFF
--- a/fourtune/docker-compose.yml
+++ b/fourtune/docker-compose.yml
@@ -204,11 +204,12 @@ services:
       # 경매(주문) 조회 Feign용 (auction-service 내부 포트 8083)
       - API_AUCTION_BASE_URL=http://auction-service:8083
       # PG사 정보 (api에서 payment로 옮겨왔다면 여기서 관리해야 함)
-      - TOSS_CLIENT_KEY=${TOSS_CLIENT_KEY}
-      - TOSS_SECRET_KEY=${TOSS_SECRET_KEY}
-      - JWT_SECRET=${JWT_SECRET}
+      - TOSS_CLIENT_KEY=${TOSS_CLIENT_KEY:-test_ck_YZ1aOwX7K8m5POogaBGV3yQxzvNP}
+      - TOSS_SECRET_KEY=${TOSS_SECRET_KEY:-test_sk_yL0qZ4G1VO512el4x29B8oWb2MQY}
+      # JWT: .env 없을 때도 도커만으로 기동 가능 (Base64, 32바이트 디코딩)
+      - JWT_SECRET=${JWT_SECRET:-lWnCnf4CTKgMltzLfUlcxbrSi36LlEfLPBz3zDy3YnE=}
       # 만약 결제 서비스에서 암호화가 필요하다면
-      - ENCRYPTION_KEY=${ENCRYPTION_KEY}
+      - ENCRYPTION_KEY=${ENCRYPTION_KEY:-fourtune-dev-aes256-encrypt!!}
     ports:
       - "8082:8081"
     depends_on:

--- a/fourtune/payment-service/src/main/resources/application.yml
+++ b/fourtune/payment-service/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 server:
   port: 8081
 
+# JWT (common/jwt JwtTokenProvider용 — 내부 API 검증 등)
+jwt:
+  secret: ${JWT_SECRET:lWnCnf4CTKgMltzLfUlcxbrSi36LlEfLPBz3zDy3YnE=}
+  access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:1800000}
+  refresh-token-expiration: ${JWT_REFRESH_TOKEN_EXPIRATION:1209600000}
+
 # 경매(주문) 조회 Feign용
 api:
   auction:


### PR DESCRIPTION
## 📌 개요
- payment-service를 Docker로 띄울 때 JwtTokenProvider 빈 생성 실패(UnsatisfiedDependencyException)가 나서, JWT 설정을 추가하고 도커 기본값을 보완

## 👩‍💻 작업 사항
- [x] payment-service application.yml에 jwt.secret, access-token-expiration, refresh-token-expiration 추가
- [x] docker-compose.yml payment-service에 JWT_SECRET, TOSS_CLIENT_KEY, TOSS_SECRET_KEY, ENCRYPTION_KEY 기본값 추가

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
