### PR TITLE
feat: 탈퇴용 진행 중 경매 확인 내부 API 추가

### DIFF
--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/InternalUserAuctionController.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/InternalUserAuctionController.java
@@ -1,0 +1,32 @@
+package com.fourtune.auction.boundedContext.auction.adapter.in.web;
+
+import com.fourtune.auction.boundedContext.auction.adapter.in.web.dto.ActiveAuctionsResponse;
+import com.fourtune.auction.boundedContext.auction.application.service.AuctionSupport;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 내부 전용 API. 다른 서비스(fourtune-api 등)에서 Feign으로 호출.
+ * - 탈퇴 처리 시: userId 기준 진행 중(ACTIVE) 경매 존재 여부 확인.
+ */
+@RestController
+@RequestMapping("/internal/users")
+@RequiredArgsConstructor
+public class InternalUserAuctionController {
+
+    private final AuctionSupport auctionSupport;
+
+    /**
+     * 해당 유저(판매자)의 진행 중(ACTIVE) 경매가 있는지 조회.
+     * 탈퇴 처리 전 호출하여 진행 중 경매가 있으면 탈퇴 불가/경고 처리에 사용.
+     */
+    @GetMapping("/{userId}/active-auctions")
+    public ResponseEntity<ActiveAuctionsResponse> getActiveAuctionsByUser(@PathVariable Long userId) {
+        long count = auctionSupport.countActiveBySellerId(userId);
+        return ResponseEntity.ok(ActiveAuctionsResponse.of(count));
+    }
+}

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/dto/ActiveAuctionsResponse.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/dto/ActiveAuctionsResponse.java
@@ -1,0 +1,13 @@
+package com.fourtune.auction.boundedContext.auction.adapter.in.web.dto;
+
+/**
+ * 탈퇴 등에서 사용: 해당 유저(판매자)의 진행 중(ACTIVE) 경매 존재 여부·개수.
+ */
+public record ActiveAuctionsResponse(
+        boolean hasActiveAuctions,
+        long count
+) {
+    public static ActiveAuctionsResponse of(long count) {
+        return new ActiveAuctionsResponse(count > 0, count);
+    }
+}

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionSupport.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionSupport.java
@@ -97,6 +97,13 @@ public class AuctionSupport {
     }
 
     /**
+     * 판매자의 진행 중(ACTIVE) 경매 개수 (탈퇴 시 확인용)
+     */
+    public long countActiveBySellerId(Long sellerId) {
+        return auctionItemRepository.countBySellerIdAndStatus(sellerId, AuctionStatus.ACTIVE);
+    }
+
+    /**
      * 진행중인 경매 목록 조회
      */
     public List<AuctionItem> findActiveAuctions() {

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/port/out/AuctionItemRepository.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/port/out/AuctionItemRepository.java
@@ -41,6 +41,11 @@ public interface AuctionItemRepository extends JpaRepository<AuctionItem, Long> 
     
     List<AuctionItem> findBySellerId(Long sellerId);
     
+    /**
+     * 판매자별·상태별 경매 개수 (탈퇴 시 진행 중 경매 확인용)
+     */
+    long countBySellerIdAndStatus(Long sellerId, AuctionStatus status);
+    
     List<AuctionItem> findByStatus(AuctionStatus status);
     
     /**

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/config/AuctionSecurityRoute.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/config/AuctionSecurityRoute.java
@@ -15,6 +15,7 @@ public class AuctionSecurityRoute implements SecurityRouteCustomizer {
         // GET 조회만 비로그인 허용 (POST/PUT/DELETE는 인증 필요)
         auth.requestMatchers(HttpMethod.GET, "/api/v1/auctions", "/api/v1/auctions/*").permitAll();
         auth.requestMatchers("/api/v1/search/**").permitAll();
+        auth.requestMatchers("/internal/**").permitAll(); // 서비스 간 호출 (탈퇴 시 진행 중 경매 확인 등)
         auth.requestMatchers("/actuator/**").permitAll(); // Docker healthcheck 허용
     }
 }

--- a/fourtune/auction-service/src/test/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/InternalUserAuctionControllerIntegrationTest.java
+++ b/fourtune/auction-service/src/test/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/InternalUserAuctionControllerIntegrationTest.java
@@ -1,0 +1,90 @@
+package com.fourtune.auction.boundedContext.auction.adapter.in.web;
+
+import com.fourtune.auction.boundedContext.auction.domain.constant.AuctionStatus;
+import com.fourtune.auction.boundedContext.auction.domain.entity.AuctionItem;
+import com.fourtune.auction.boundedContext.auction.port.out.AuctionItemRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * 내부 API: userId 기준 진행 중(ACTIVE) 경매 존재 여부 조회.
+ * 탈퇴 처리 시 Feign으로 호출되는 API 검증.
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+class InternalUserAuctionControllerIntegrationTest {
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AuctionItemRepository auctionItemRepository;
+
+    @MockitoBean
+    private com.fourtune.auction.adapter.out.api.UserClient userClient;
+    @MockitoBean
+    private com.fourtune.auction.boundedContext.auction.application.service.RedisViewCountService redisViewCountService;
+    @MockitoBean
+    private com.fourtune.auction.infrastructure.kafka.AuctionKafkaProducer auctionKafkaProducer;
+
+    @BeforeEach
+    void setUp() {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(context).build();
+    }
+
+    @Test
+    @DisplayName("GET /internal/users/{userId}/active-auctions — 진행 중 경매 없으면 hasActiveAuctions false, count 0")
+    void getActiveAuctions_noActive_returnsFalseAndZero() throws Exception {
+        long userIdNoAuctions = 99_999L;
+
+        mockMvc.perform(get("/internal/users/{userId}/active-auctions", userIdNoAuctions))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.has_active_auctions").value(false))
+                .andExpect(jsonPath("$.count").value(0));
+    }
+
+    @Test
+    @DisplayName("GET /internal/users/{userId}/active-auctions — 진행 중 경매 있으면 hasActiveAuctions true, count >= 1")
+    void getActiveAuctions_hasActive_returnsTrueAndCount() throws Exception {
+        Long sellerId = 100L;
+        AuctionItem active = AuctionItem.builder()
+                .sellerId(sellerId)
+                .title("진행중 경매")
+                .description("설명")
+                .category(com.fourtune.auction.boundedContext.auction.domain.constant.Category.ETC)
+                .startPrice(BigDecimal.valueOf(5000))
+                .bidUnit(500)
+                .auctionStartTime(LocalDateTime.now().minusHours(1))
+                .auctionEndTime(LocalDateTime.now().plusDays(1))
+                .status(AuctionStatus.ACTIVE)
+                .currentPrice(BigDecimal.valueOf(5000))
+                .build();
+        auctionItemRepository.save(active);
+
+        mockMvc.perform(get("/internal/users/{userId}/active-auctions", sellerId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.has_active_auctions").value(true))
+                .andExpect(jsonPath("$.count").value(1));
+    }
+}


### PR DESCRIPTION
## 📌 개요
- **배경:** 회원 탈퇴 시 해당 유저가 진행 중(ACTIVE)인 경매를 보유하고 있으면 탈퇴를 막거나 경고해야 하며, 이 검증을 Feign으로 서비스 간 호출해 처리하기로 함.
- **목적:** auction-service에 “userId 기준 진행 중 경매 존재 여부·개수”를 반환하는 **내부 전용 API**를 추가해, fourtune-api(또는 탈퇴 담당 서비스)에서 Feign으로 호출할 수 있게 함.

## 👩‍💻 작업 사항
- [x] **AuctionItemRepository** `countBySellerIdAndStatus(sellerId, status)` 추가
- [x] **AuctionSupport** `countActiveBySellerId(sellerId)` 추가
- [x] **InternalUserAuctionController** `GET /internal/users/{userId}/active-auctions` 추가, 응답 DTO `ActiveAuctionsResponse`(has_active_auctions, count)
- [x] **AuctionSecurityRoute** `/internal/**` permitAll

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
