### PR TITLE
feat: MSA Swagger 통합 및 로컬 CORS 문제 해결

### DIFF
--- a/fourtune/auction-service/src/main/resources/application.yml
+++ b/fourtune/auction-service/src/main/resources/application.yml
@@ -84,6 +84,16 @@ search:
   max-from: 10000 # Deep paging 최대 from 값
   max-keyword-length: 100 # 검색 키워드 최대 길이
 
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+    enabled: true
+  swagger-ui:
+    enabled: false          # 각 서비스 자체 UI는 비활성 (aggregation용 엔드포인트만 노출)
+  paths-to-exclude:
+    - /actuator/**
+    - /error
+
 feature:
   kafka:
     enabled: true

--- a/fourtune/common/jwt/src/main/java/com/fourtune/jwt/GlobalJwtSecurityConfig.java
+++ b/fourtune/common/jwt/src/main/java/com/fourtune/jwt/GlobalJwtSecurityConfig.java
@@ -44,7 +44,7 @@ public class GlobalJwtSecurityConfig {
                 .authorizeHttpRequests(auth -> {
                     // 1. 공통으로 열어두는 예외 경로 (Preflight 등)
                     auth.requestMatchers(org.springframework.web.cors.CorsUtils::isPreFlightRequest).permitAll();
-                    auth.requestMatchers("/actuator/prometheus", "/v3/api-docs").permitAll();
+                    auth.requestMatchers("/actuator/prometheus", "/v3/api-docs", "/v3/api-docs/**").permitAll();
 
                     // 2. 서비스 고유의 라우팅 확장점이 있다면 조립해줌
                     routeCustomizer.ifPresent(customizer -> customizer.customize(auth));

--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/config/ApiSecurityConfig.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/config/ApiSecurityConfig.java
@@ -28,38 +28,46 @@ public class ApiSecurityConfig {
         private final DefaultOAuth2UserService customOAuth2UserService;
         private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
-    @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        http
-                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
-                .csrf(AbstractHttpConfigurer::disable)
-                .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(org.springframework.web.cors.CorsUtils::isPreFlightRequest).permitAll()
-                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs", "/swagger-ui.html",
-                                "/api/auth/reissue", "/token.html", "/firebase-messaging-sw.js")
-                        .permitAll()
-                        .requestMatchers("/api/auth/**", "/api/users/signup").permitAll()
-                        .requestMatchers("/api/v1/search/auction-items").permitAll()
-                        .requestMatchers("/api/v1/search/recent").permitAll()
-                        .requestMatchers("/tosspay.html").permitAll()
-                        .requestMatchers("/", "/index.html", "/oauth2/**", "/login-success").permitAll()
-                        .requestMatchers("/css/**", "/js/**", "/images/**", "/favicon.ico").permitAll()
-                        .requestMatchers("/error").permitAll()
-                        .requestMatchers("/actuator/prometheus").permitAll()
-                        .requestMatchers("/api/test/**").permitAll() // 성능 테스트용
-                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
-                        .anyRequest().authenticated())
-                // fourtune-api는 OAuth를 관장하므로 아래 설정 활성화
-                .oauth2Login(oauth2 -> oauth2
-                        .userInfoEndpoint(userInfo -> userInfo
-                                .userService(customOAuth2UserService))
-                        .successHandler(oAuth2SuccessHandler))
-                // 직접 JWT 필터 부착
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
-                        UsernamePasswordAuthenticationFilter.class);
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+                http
+                                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
+                                .csrf(AbstractHttpConfigurer::disable)
+                                .formLogin(AbstractHttpConfigurer::disable)
+                                .httpBasic(AbstractHttpConfigurer::disable)
+                                .sessionManagement(session -> session
+                                                .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                                .authorizeHttpRequests(auth -> auth
+                                                .requestMatchers(
+                                                                org.springframework.web.cors.CorsUtils::isPreFlightRequest)
+                                                .permitAll()
+                                                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/v3/api-docs",
+                                                                "/swagger-ui.html",
+                                                                "/api/auth/reissue", "/token.html",
+                                                                "/firebase-messaging-sw.js")
+                                                .permitAll()
+                                                .requestMatchers("/api/auth/**", "/api/users/signup").permitAll()
+                                                .requestMatchers("/api/v1/search/auction-items").permitAll()
+                                                .requestMatchers("/api/v1/search/recent").permitAll()
+                                                .requestMatchers("/tosspay.html").permitAll()
+                                                .requestMatchers("/", "/index.html", "/oauth2/**", "/login-success")
+                                                .permitAll()
+                                                .requestMatchers("/css/**", "/js/**", "/images/**", "/favicon.ico")
+                                                .permitAll()
+                                                .requestMatchers("/error").permitAll()
+                                                .requestMatchers("/actuator/prometheus").permitAll()
+                                                .requestMatchers("/api/test/**").permitAll() // 성능 테스트용
+                                                .requestMatchers("/api/internal/**").hasRole("INTERNAL")
+                                                .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                                                .anyRequest().authenticated())
+                                // fourtune-api는 OAuth를 관장하므로 아래 설정 활성화
+                                .oauth2Login(oauth2 -> oauth2
+                                                .userInfoEndpoint(userInfo -> userInfo
+                                                                .userService(customOAuth2UserService))
+                                                .successHandler(oAuth2SuccessHandler))
+                                // 직접 JWT 필터 부착
+                                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider),
+                                                UsernamePasswordAuthenticationFilter.class);
 
                 return http.build();
         }
@@ -68,6 +76,7 @@ public class ApiSecurityConfig {
         public CorsConfigurationSource corsConfigurationSource() {
                 CorsConfiguration configuration = new CorsConfiguration();
                 configuration.setAllowedOriginPatterns(List.of(
+                                "http://localhost", "http://localhost:8080",
                                 "http://localhost:5173", "http://localhost:3000",
                                 "https://fourtune.store", "https://www.fourtune.store", "https://*.vercel.app"));
                 configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));

--- a/fourtune/fourtune-api/src/main/resources/application.yml
+++ b/fourtune/fourtune-api/src/main/resources/application.yml
@@ -50,9 +50,19 @@ springdoc:
     operations-sorter: method
     tags-sorter: alpha
     try-it-out-enabled: true
+    urls:
+      - name: fourtune-api
+        url: /v3/api-docs
+      - name: auction-service
+        url: /v3/api-docs/auction
+      - name: payment-service
+        url: /v3/api-docs/payment
+      - name: recommendation-service
+        url: /v3/api-docs/recommendation
   paths-to-exclude:
     - /actuator/**
     - /error
+    - /api/internal/**
 
 # Actuator & Prometheus 설정
 management:

--- a/fourtune/nginx/nginx.dev.conf
+++ b/fourtune/nginx/nginx.dev.conf
@@ -206,6 +206,28 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        # 서비스별 OpenAPI docs 라우팅
+        location /v3/api-docs/auction {
+            rewrite ^/v3/api-docs/auction(.*)$ /v3/api-docs$1 break;
+            proxy_pass http://auction;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+        }
+
+        location /v3/api-docs/payment {
+            rewrite ^/v3/api-docs/payment(.*)$ /v3/api-docs$1 break;
+            proxy_pass http://payment;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+        }
+
+        location /v3/api-docs/recommendation {
+            rewrite ^/v3/api-docs/recommendation(.*)$ /v3/api-docs$1 break;
+            proxy_pass http://recommendation;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+        }
+
         # OpenAPI docs
         location /v3/api-docs {
             proxy_pass http://backend;

--- a/fourtune/nginx/nginx.local.conf
+++ b/fourtune/nginx/nginx.local.conf
@@ -200,6 +200,28 @@ http {
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         }
 
+        # 서비스별 OpenAPI docs 라우팅
+        location /v3/api-docs/auction {
+            rewrite ^/v3/api-docs/auction(.*)$ /v3/api-docs$1 break;
+            proxy_pass http://auction;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+        }
+
+        location /v3/api-docs/payment {
+            rewrite ^/v3/api-docs/payment(.*)$ /v3/api-docs$1 break;
+            proxy_pass http://payment;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+        }
+
+        location /v3/api-docs/recommendation {
+            rewrite ^/v3/api-docs/recommendation(.*)$ /v3/api-docs$1 break;
+            proxy_pass http://recommendation;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+        }
+
         location /v3/api-docs {
             proxy_pass http://backend;
             proxy_http_version 1.1;

--- a/fourtune/payment-service/src/main/resources/application.yml
+++ b/fourtune/payment-service/src/main/resources/application.yml
@@ -58,3 +58,13 @@ custom:
   services:
     payout_url: ${PAYOUT_SERVICE_URL:http://payment-service:8081}
     cash_url: ${CASH_SERVICE_URL:http://payment-service:8081}
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+    enabled: true
+  swagger-ui:
+    enabled: false          # 각 서비스 자체 UI는 비활성 (aggregation용 엔드포인트만 노출)
+  paths-to-exclude:
+    - /actuator/**
+    - /error

--- a/fourtune/recommendation-service/src/main/resources/application.yml
+++ b/fourtune/recommendation-service/src/main/resources/application.yml
@@ -63,3 +63,13 @@ spring.ai:
 api:
   search:
     base-url: ${API_SEARCH_BASE_URL:http://localhost:8080}
+
+springdoc:
+  api-docs:
+    path: /v3/api-docs
+    enabled: true
+  swagger-ui:
+    enabled: false          # 각 서비스 자체 UI는 비활성 (aggregation용 엔드포인트만 노출)
+  paths-to-exclude:
+    - /actuator/**
+    - /error


### PR DESCRIPTION
## 📌 개요
현재 Swagger 관련 문제가 두 가지 발생하고 있음.

1. 로컬 docker-compose 환경에서 CORS 미허용으로 Swagger UI fetch 차단
- http://localhost origin 미허용
- v3/api-docs 요청이 브라우저에서 차단됨

2. 개발 서버에서 fourtune-api만 Swagger에 노출
- springdoc 의존성이 fourtune-api에만 존재
- nginx가 /v3/api-docs를 fourtune-api로만 라우팅
- 다른 서비스(auction/payment/recommendation)는 OpenAPI 엔드포인트 자체가 없음

결과적으로 로컬에서 Swagger 정상 동작하지 않아, 개발 서버에서 마이크로서비스 전체 API 가시성 부족해짐

## 👩‍💻 작업 사항
- [x] 로컬 Swagger CORS 수정
- ApiSecurityConfig.java에 http://localhost, http://localhost:8080 origin 추가
---
- [x] 각 서비스에 springdoc 추가 (auction/payment/recommendation)
---
- [x] 각 서비스에서 /v3/api-docs/** Security 허용
---
- [x] 4. nginx에 서비스별 api-docs 라우팅 추가
- /v3/api-docs/auction, /v3/api-docs/payment, /v3/api-docs/recommendation
---
- [x] fourtune-api Swagger aggregation 설정
- springdoc.swagger-ui.urls에 각 서비스 URL 등록

## ✅ 테스트 결과
<img width="1485" height="629" alt="image" src="https://github.com/user-attachments/assets/c3b33a68-200e-462c-bd7a-8841704c7f63" />

## 🔗 관련 이슈
- close #359
