### PR TITLE
[설정] 프로덕션 환경 보안 및 배포 설정 개선

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -309,7 +309,7 @@ jobs:
             cd fourtune
             echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
             docker compose -f docker-compose.prod.yml pull
-            docker compose -f docker-compose.prod.yml up -d --no-deps
+            docker compose -f docker-compose.prod.yml up -d
             docker system prune -f
             echo "Waiting for service to start..."
             sleep 30

--- a/fourtune/docker-compose.prod.yml
+++ b/fourtune/docker-compose.prod.yml
@@ -1,5 +1,4 @@
 # 프로덕션 환경용 Docker Compose (Updated for t3.large)
-version: "3.8"
 
 services:
   # PostgreSQL Database
@@ -10,8 +9,6 @@ services:
       POSTGRES_DB: ${DB_NAME:-fourtune_db}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
-    ports:
-      - "5432:5432"
     volumes:
       - postgres_data_prod:/var/lib/postgresql/data
       - ./init-db:/docker-entrypoint-initdb.d
@@ -42,8 +39,6 @@ services:
   redis:
     image: redis:7-alpine
     container_name: fourtune-redis-prod
-    ports:
-      - "6379:6379"
     volumes:
       - redis_data_prod:/data
     networks:
@@ -56,7 +51,7 @@ services:
           cpus: "0.25"
           memory: 512M
     healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      test: ["CMD-SHELL", "redis-cli -a ${REDIS_PASSWORD} ping | grep PONG"]
       interval: 10s
       timeout: 3s
       retries: 5
@@ -75,9 +70,6 @@ services:
       - xpack.security.enabled=false
       # 중요: 8GB 램 환경에서는 힙메모리를 1GB로 줄여야 OOM 방지됨
       - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
-    ports:
-      - "9200:9200"
-      - "9300:9300"
     volumes:
       - elasticsearch_data_prod:/usr/share/elasticsearch/data
     networks:
@@ -103,6 +95,43 @@ services:
         max-size: "10m"
         max-file: "3"
 
+  # Redpanda (Kafka API 호환, Zookeeper 불필요)
+  redpanda:
+    image: docker.redpanda.com/redpandadata/redpanda:v24.2.2
+    container_name: fourtune-redpanda-prod
+    command:
+      - redpanda
+      - start
+      - --kafka-addr internal://0.0.0.0:9092,external://0.0.0.0:19092
+      - --advertise-kafka-addr internal://redpanda:9092,external://localhost:19092
+      - --smp 1
+      - --memory 512M
+      - --default-log-level=warn
+    volumes:
+      - redpanda_data_prod:/var/lib/redpanda/data
+    networks:
+      - fourtune-network
+    restart: always
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 768M
+        reservations:
+          cpus: "0.25"
+          memory: 512M
+    healthcheck:
+      test: ["CMD", "rpk", "cluster", "health"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    logging:
+      driver: "json-file"
+      options:
+        max-size: "10m"
+        max-file: "3"
+
   # Spring Boot Application
   app:
     image: ghcr.io/prgrms-be-adv-devcourse/fourtune:latest
@@ -118,6 +147,8 @@ services:
       - REDIS_PORT=6379
       - REDIS_PASSWORD=${REDIS_PASSWORD}
       - ELASTICSEARCH_URIS=http://elasticsearch:9200
+      - KAFKA_BOOTSTRAP_SERVERS=redpanda:9092
+      - API_AUCTION_BASE_URL=http://auction-service:8083
       - JWT_SECRET=${JWT_SECRET}
       - ENCRYPTION_KEY=${ENCRYPTION_KEY}
       - AWS_ACCESS_KEY=${AWS_ACCESS_KEY}
@@ -141,6 +172,8 @@ services:
       redis:
         condition: service_healthy
       elasticsearch:
+        condition: service_healthy
+      redpanda:
         condition: service_healthy
     networks:
       - fourtune-network
@@ -175,7 +208,7 @@ services:
         max-file: "3"
 
   payment-service:
-    image: ghcr.io/prgrms-be-adv-devcourse/payment-service:latest # GHCR에 올린 결제 서비스 이미지
+    image: ghcr.io/prgrms-be-adv-devcourse/payment-service:latest
     container_name: payment-app-prod
     env_file:
       - .env
@@ -187,6 +220,9 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
+      - KAFKA_BOOTSTRAP_SERVERS=redpanda:9092
+      - API_AUCTION_BASE_URL=http://auction-service:8083
       - JWT_SECRET=${JWT_SECRET}
       # 결제 서비스에 필요한 키만 선별해서 추가
       - TOSS_SECRET_KEY=${TOSS_SECRET_KEY}
@@ -198,10 +234,11 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      redpanda:
+        condition: service_healthy
     networks:
       - fourtune-network
     restart: always
-    # 운영 환경이므로 리소스 제한도 걸어주는 것이 좋습니다
     deploy:
       resources:
         limits:
@@ -220,6 +257,7 @@ services:
       - DB_PASSWORD=${DB_PASSWORD}
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
       - KAFKA_BOOTSTRAP_SERVERS=redpanda:9092
       - SERVER_PORT=8083
       - API_USER_BASE_URL=http://app:8080
@@ -233,6 +271,8 @@ services:
       postgres:
         condition: service_healthy
       redis:
+        condition: service_healthy
+      redpanda:
         condition: service_healthy
       app:
         condition: service_started
@@ -277,8 +317,10 @@ services:
       - KAFKA_BOOTSTRAP_SERVERS=redpanda:9092
       - REDIS_HOST=redis
       - REDIS_PORT=6379
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
       - AI_PROVIDER=${AI_PROVIDER}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
+      - API_SEARCH_BASE_URL=http://app:8080
       # JWT
       - JWT_SECRET=${JWT_SECRET}
       # AWS
@@ -298,6 +340,10 @@ services:
         condition: service_healthy
       redis:
         condition: service_healthy
+      redpanda:
+        condition: service_healthy
+      app:
+        condition: service_started
     networks:
       - fourtune-network
     restart: always
@@ -335,6 +381,9 @@ services:
       - nginx_logs:/var/log/nginx
     depends_on:
       - app
+      - payment-service
+      - auction-service
+      - recommendation-service
     networks:
       - fourtune-network
     restart: always
@@ -379,13 +428,9 @@ volumes:
     driver: local
   elasticsearch_data_prod:
     driver: local
+  redpanda_data_prod:
+    driver: local
   nginx_logs:
-    driver: local
-  zookeeper_data_prod:
-    driver: local
-  zookeeper_log_prod:
-    driver: local
-  kafka_data_prod:
     driver: local
 
 networks:

--- a/fourtune/payment-service/src/main/resources/application.yml
+++ b/fourtune/payment-service/src/main/resources/application.yml
@@ -37,7 +37,7 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: true
+    show-sql: false
 
   # redis, kafka bootstrap-servers, jwt → application-common.yml
   data:


### PR DESCRIPTION
## 📌 관련 이슈
close #375

## 📝 변경 사항

### 🔴 Critical
- **인프라 서비스 외부 포트 노출 제거** (`docker-compose.prod.yml`)
  - postgres(5432), redis(6379), elasticsearch(9200/9300), redpanda(9092/19092) `ports` 블록 제거
  - 인터넷에서 DB/캐시/메시지브로커에 직접 접근 불가, Docker 내부 통신만 허용

- **CI/CD `--no-deps` 플래그 제거** (`.github/workflows/ci-cd.yml`)
  - `docker compose up -d --no-deps` → `docker compose up -d`
  - `depends_on` 헬스체크 조건(`service_healthy`)이 정상 동작하여 DB/Redis/Redpanda 준비 후 앱 기동 보장

### 🟠 High
- **recommendation-service `depends_on`에 `app` 추가** (`docker-compose.prod.yml`)
  - `API_SEARCH_BASE_URL=http://app:8080` 참조 시 `app`이 먼저 기동됨을 보장

### 🟡 Minor
- **payment-service `show-sql: false`** (`payment-service/src/main/resources/application.yml`)
  - 운영 환경에서 모든 SQL 쿼리가 로그에 출력되는 문제 수정

## ✅ 테스트
- [x] docker-compose.prod.yml 포트 제거 후 서비스 간 내부 통신 정상 확인
- [x] 배포 시 depends_on 헬스체크 조건 준수 확인