### PR TITLE
fix: 최근 검색어 API 응답 형식을 ApiResponse 표준으로 통일

### DIFF
--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/adapter/in/web/RecentSearchController.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/adapter/in/web/RecentSearchController.java
@@ -1,6 +1,7 @@
 package com.fourtune.auction.boundedContext.search.adapter.in.web;
 
 import com.fourtune.auction.boundedContext.search.application.service.RecentSearchService;
+import com.fourtune.core.dto.ApiResponse;
 import com.fourtune.shared.auth.dto.UserContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,12 +19,12 @@ public class RecentSearchController {
 
     // 최근 검색어 목록 조회
     @GetMapping
-    public ResponseEntity<List<String>> getRecentKeywords(@AuthenticationPrincipal UserContext user) {
+    public ResponseEntity<ApiResponse<List<String>>> getRecentKeywords(@AuthenticationPrincipal UserContext user) {
         if (user == null) {
-            return ResponseEntity.ok(List.of());
+            return ResponseEntity.ok(ApiResponse.success(List.of()));
         }
         List<String> keywords = recentSearchService.getKeywords(user.id());
-        return ResponseEntity.ok(keywords);
+        return ResponseEntity.ok(ApiResponse.success(keywords));
     }
 
     // 최근 검색어 삭제

--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/adapter/in/web/RecentSearchControllerTest.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/adapter/in/web/RecentSearchControllerTest.java
@@ -73,14 +73,15 @@ class RecentSearchControllerTest {
         List<String> mockKeywords = List.of("keyword1", "keyword2");
         given(recentSearchService.getKeywords(1L)).willReturn(mockKeywords);
 
-        // when & then: GET 요청 시 200 OK와 함께 리스트 내용 검증
+        // when & then: GET 요청 시 200 OK와 함께 ApiResponse 형식으로 리스트 내용 검증
         mockMvc.perform(get("/api/v1/search/recent"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray()) // 배열인지 확인
-                .andExpect(jsonPath("$.length()").value(2)) // 개수 확인
-                .andExpect(jsonPath("$[0]").value("keyword1")) // 첫 번째 값 확인
-                .andExpect(jsonPath("$[1]").value("keyword2")); // 두 번째 값 확인
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(2))
+                .andExpect(jsonPath("$.data[0]").value("keyword1"))
+                .andExpect(jsonPath("$.data[1]").value("keyword2"));
     }
 
     @Test
@@ -95,8 +96,9 @@ class RecentSearchControllerTest {
         noAuthMockMvc.perform(get("/api/v1/search/recent"))
                 .andDo(print())
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$").isArray())
-                .andExpect(jsonPath("$.length()").value(0));
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").isArray())
+                .andExpect(jsonPath("$.data.length()").value(0));
     }
 
     @Test


### PR DESCRIPTION
## 📌 개요
- 현재 서비스 내 다른 주요 API(입찰, 결제 등)는 ApiResponse 공통 래퍼를 사용하여 데이터를 반환하지만, RecentSearchController 는 List<String>을 직접 반환하고 있습니다. 프론트엔드(realApi.ts)는 모든 API가 ApiResponse 형식을 따를 것으로 가정하고 response.data.data에 접근하고 있어, 결과적으로 최근 검색어가 화면에 표시되지 않는 버그가 발생하고 있습니다.

이를 해결하기 위해 RecentSearchController 의 응답 형식을 프로젝트 표준인 ApiResponse 로 감싸도록 수정했습니다.

## 👩‍💻 작업 사항
- [x] RecentSearchController 응답을 ApiResponse.success()로 래핑
- [x] 변경사항에 맞춰 단위테스트 코드 수정

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #374
