### PR TITLE
[설정] 운영 환경 서비스 기동 오류 수정

### DIFF
--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/adapter/out/api/FeignErrorDecoder.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/adapter/out/api/FeignErrorDecoder.java
@@ -26,9 +26,6 @@ public class FeignErrorDecoder implements ErrorDecoder {
 
     @Override
     public Exception decode(String methodKey, Response response) {
-        if (response.status() < 400) {
-            return null;
-        }
         ErrorCode errorCode = parseErrorCode(response);
         log.warn("[Feign] {} -> status={}, errorCode={}", methodKey, response.status(), errorCode.getCode());
         return new BusinessException(errorCode);

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/config/AuctionSecurityRoute.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/config/AuctionSecurityRoute.java
@@ -15,6 +15,7 @@ public class AuctionSecurityRoute implements SecurityRouteCustomizer {
         // GET 조회만 비로그인 허용 (POST/PUT/DELETE는 인증 필요)
         auth.requestMatchers(HttpMethod.GET, "/api/v1/auctions", "/api/v1/auctions/*").permitAll();
         auth.requestMatchers("/api/v1/search/**").permitAll();
+        auth.requestMatchers("/api/v1/orders/public/**").permitAll(); // 서비스 간 Feign 호출 (payment-service)
         auth.requestMatchers("/internal/**").permitAll(); // 서비스 간 호출 (탈퇴 시 진행 중 경매 확인 등)
         auth.requestMatchers("/actuator/**").permitAll(); // Docker healthcheck 허용
     }

--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/config/ApiSecurityConfig.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/config/ApiSecurityConfig.java
@@ -57,6 +57,7 @@ public class ApiSecurityConfig {
                                                 .requestMatchers("/error").permitAll()
                                                 .requestMatchers("/actuator/prometheus").permitAll()
                                                 .requestMatchers("/api/test/**").permitAll() // 성능 테스트용
+                                                .requestMatchers("/api/users/nicknames").permitAll() // 서비스 간 Feign 호출
                                                 .requestMatchers("/api/internal/**").hasRole("INTERNAL")
                                                 .requestMatchers("/api/admin/**").hasRole("ADMIN")
                                                 .anyRequest().authenticated())


### PR DESCRIPTION
## 📌 관련 이슈
close #381

## 📝 변경 사항

### 🔴 서비스 간 Feign 호출 인증 오류 (401)

**fourtune-api `ApiSecurityConfig`**
- `/api/users/nicknames` permitAll 추가
- auction-service 스케줄러가 JWT 없이 Feign 호출 → 401로 경매 시작 실패하던 문제 수정

**auction-service `AuctionSecurityRoute`**
- `/api/v1/orders/public/**` permitAll 추가
- payment-service가 주문 조회 Feign 호출 시 401 반환되던 문제 수정

**auction-service `FeignErrorDecoder`**
- `decode()` 메서드의 null 반환 코드 제거
- Feign 에러 응답 수신 시 NPE 발생하던 버그 수정

## ✅ 테스트
- [ ] 경매 스케줄러 시작 시 auction_bids 생성 및 닉네임 조회 정상 동작 확인
- [ ] payment-service 주문 조회 Feign 호출 정상 동작 확인