### PR TITLE
fix: 로컬 및 개발 환경 추천 서비스의 검색 API 통신 주소 수정

### DIFF
--- a/fourtune/docker-compose.dev.yml
+++ b/fourtune/docker-compose.dev.yml
@@ -290,7 +290,6 @@ services:
       - REDIS_PORT=6379
       - AI_PROVIDER=${AI_PROVIDER:-ollama}
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
-      - SEARCH_BASE_URL=http://app:8080
       - API_SEARCH_BASE_URL=http://app:8080
       - SERVER_PORT=8084
       - MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE=health,info,prometheus,metrics

--- a/fourtune/docker-compose.yml
+++ b/fourtune/docker-compose.yml
@@ -292,7 +292,6 @@ services:
       - AI_PROVIDER=${AI_PROVIDER:-ollama}
       - OLLAMA_BASE_URL=http://host.docker.internal:11434
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - SEARCH_BASE_URL=http://fourtune-api:8080
       - API_SEARCH_BASE_URL=http://fourtune-api:8080
       - SERVER_PORT=8084
       - MANAGEMENT_ENDPOINTS_WEB_EXPOSURE_INCLUDE=health,info,prometheus,metrics


### PR DESCRIPTION
## 📌 개요
- 로컬 및 개발 환경의 도커 네트워크 내에서 recommendation-service가 fourtune-api를 찾지 못하던 네트워크 설정 오류를 해결하고, 서비스 간 통신 주소를 정상화했습니다.

## 👩‍💻 작업 사항
- [x] docker-compose.yml가  http://fourtune-api:8080을 바라보도록 수정
- [x] docker-compose-dev.yml가  http://app:8080을 바라보도록 수정

## ✅ 테스트 결과
<img width="1061" height="898" alt="image" src="https://github.com/user-attachments/assets/622af423-3943-4b47-b2ae-6220d98f1817" />

## 🔗 관련 이슈
- close #385
