### PR TITLE
fix: Feign 장애로 인한 경매 ACTIVE 전환 실패 및 KST 타임존 버그 수정

### DIFF
--- a/fourtune/Dockerfile
+++ b/fourtune/Dockerfile
@@ -49,6 +49,7 @@ ENTRYPOINT ["java", \
   "-XX:+UseContainerSupport", \
   "-XX:MaxRAMPercentage=75.0", \
   "-Djava.security.egd=file:/dev/./urandom", \
+  "-Duser.timezone=Asia/Seoul", \
   "-jar", \
   "app.jar"]
 

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/adapter/out/api/FeignConfig.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/adapter/out/api/FeignConfig.java
@@ -1,11 +1,39 @@
 package com.fourtune.auction.adapter.out.api;
 
+import feign.Request;
+import feign.Retryer;
 import feign.codec.ErrorDecoder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
+import java.time.Duration;
+
 @Configuration
 public class FeignConfig {
+
+    /**
+     * Feign 타임아웃 설정.
+     * getNicknamesByIds() 같은 비핵심 Feign 호출이 REQUIRES_NEW 트랜잭션 안에서
+     * 무한 대기하면 DB 커넥션을 점유한 채 스케줄러가 블록된다.
+     * connectTimeout: 2s, readTimeout: 3s 로 제한한다.
+     */
+    @Bean
+    public Request.Options options() {
+        return new Request.Options(
+                Duration.ofSeconds(2),
+                Duration.ofSeconds(3),
+                true
+        );
+    }
+
+    /**
+     * 재시도 정책: 100ms 간격, 최대 500ms, 최대 2회.
+     * 일시적 네트워크 오류에 대해 재시도 후 빠르게 포기한다.
+     */
+    @Bean
+    public Retryer retryer() {
+        return new Retryer.Default(100, 500, 2);
+    }
 
     @Bean
     public ErrorDecoder errorDecoder(FeignErrorDecoder decoder) {

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/scheduler/OrderScheduler.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/scheduler/OrderScheduler.java
@@ -10,6 +10,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 
 /**
@@ -50,7 +51,7 @@ public class OrderScheduler {
                 buyNowPendingTimeoutMinutes, bidPendingTimeoutHours);
 
         try {
-            LocalDateTime now = LocalDateTime.now();
+            LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
             LocalDateTime buyNowCutoff = now.minusMinutes(buyNowPendingTimeoutMinutes);
             LocalDateTime bidCutoff = now.minusHours(bidPendingTimeoutHours);
 

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionCreateUseCase.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionCreateUseCase.java
@@ -27,96 +27,99 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class AuctionCreateUseCase {
 
-    private static final String AGGREGATE_TYPE_AUCTION = "Auction";
+        private static final String AGGREGATE_TYPE_AUCTION = "Auction";
 
-    private final AuctionSupport auctionSupport;
-    private final EventPublisher eventPublisher;
-    private final UserPort userPort;
-    private final EventPublishingConfig eventPublishingConfig;
-    private final OutboxService outboxService;
-    // private final S3Service s3Service; // TODO: 나중에 추가
+        private final AuctionSupport auctionSupport;
+        private final EventPublisher eventPublisher;
+        private final UserPort userPort;
+        private final EventPublishingConfig eventPublishingConfig;
+        private final OutboxService outboxService;
+        // private final S3Service s3Service; // TODO: 나중에 추가
 
-    /**
-     * 경매 등록
-     */
-    @Transactional
-    public Long createAuction(Long sellerId, AuctionItemCreateRequest request) {
-        // 1. 경매 엔티티 생성 (정적 팩토리 메서드 사용)
-        AuctionItem auctionItem = AuctionItem.create(
-                sellerId,
-                request.title(),
-                request.description(),
-                request.category(),
-                request.startPrice(),
-                request.bidUnit() != null ? request.bidUnit() : 1000,
-                request.buyNowPrice(),
-                request.buyNowPrice() != null,  // buyNowEnabled
-                request.auctionStartTime(),
-                request.auctionEndTime()
-        );
-        
-        // 2. DB 저장
-        AuctionItem savedAuction = auctionSupport.save(auctionItem);
-        Long aggregateId = savedAuction.getId();
+        /**
+         * 경매 등록
+         */
+        @Transactional
+        public Long createAuction(Long sellerId, AuctionItemCreateRequest request) {
+                // 1. 경매 엔티티 생성 (정적 팩토리 메서드 사용)
+                AuctionItem auctionItem = AuctionItem.create(
+                                sellerId,
+                                request.title(),
+                                request.description(),
+                                request.category(),
+                                request.startPrice(),
+                                request.bidUnit() != null ? request.bidUnit() : 1000,
+                                request.buyNowPrice(),
+                                request.buyNowPrice() != null, // buyNowEnabled
+                                request.auctionStartTime(),
+                                request.auctionEndTime());
 
-        // 3. 이벤트 발행 (Kafka 사용 시 Outbox, 아니면 Spring Event)
-        AuctionCreatedEvent createdEvent = new AuctionCreatedEvent(
-                savedAuction.getId(),
-                sellerId,
-                savedAuction.getCategory().toString()
-        );
-        if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
-            outboxService.append(AGGREGATE_TYPE_AUCTION, aggregateId, AuctionEventType.AUCTION_CREATED.name(), Map.of("eventType", AuctionEventType.AUCTION_CREATED.name(), "aggregateId", aggregateId, "data", createdEvent));
-        } else {
-            eventPublisher.publish(createdEvent);
+                // 2. DB 저장
+                AuctionItem savedAuction = auctionSupport.save(auctionItem);
+                Long aggregateId = savedAuction.getId();
+
+                // 3. 이벤트 발행 (Kafka 사용 시 Outbox, 아니면 Spring Event)
+                AuctionCreatedEvent createdEvent = new AuctionCreatedEvent(
+                                savedAuction.getId(),
+                                sellerId,
+                                savedAuction.getCategory().toString());
+                if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+                        outboxService.append(AGGREGATE_TYPE_AUCTION, aggregateId,
+                                        AuctionEventType.AUCTION_CREATED.name(),
+                                        Map.of("eventType", AuctionEventType.AUCTION_CREATED.name(), "aggregateId",
+                                                        aggregateId, "data", createdEvent));
+                } else {
+                        eventPublisher.publish(createdEvent);
+                }
+
+                // 4. Search 인덱싱 전용 이벤트 발행 (스냅샷 형태)
+                String thumbnailUrl = extractThumbnailUrl(savedAuction);
+                String sellerName = userPort.getNicknamesByIds(Set.of(sellerId)).getOrDefault(sellerId, null);
+                AuctionItemCreatedEvent itemCreatedEvent = new AuctionItemCreatedEvent(
+                                savedAuction.getId(),
+                                sellerId,
+                                sellerName,
+                                savedAuction.getTitle(),
+                                savedAuction.getDescription(),
+                                savedAuction.getCategory().toString(),
+                                savedAuction.getStatus().toString(),
+                                savedAuction.getStartPrice(),
+                                savedAuction.getCurrentPrice(),
+                                savedAuction.getBuyNowPrice(),
+                                savedAuction.getBuyNowEnabled(),
+                                savedAuction.getAuctionStartTime(),
+                                savedAuction.getAuctionEndTime(),
+                                thumbnailUrl,
+                                savedAuction.getCreatedAt(),
+                                savedAuction.getUpdatedAt(),
+                                savedAuction.getViewCount(),
+                                savedAuction.getBidCount(),
+                                savedAuction.getWatchlistCount());
+                if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
+                        outboxService.append(AGGREGATE_TYPE_AUCTION, aggregateId,
+                                        AuctionEventType.AUCTION_ITEM_CREATED.name(),
+                                        Map.of("eventType", AuctionEventType.AUCTION_ITEM_CREATED.name(), "aggregateId",
+                                                        aggregateId, "data", itemCreatedEvent));
+                } else {
+                        eventPublisher.publish(itemCreatedEvent);
+                }
+
+                // 5. 경매 ID 반환
+                return savedAuction.getId();
         }
 
-        // 4. Search 인덱싱 전용 이벤트 발행 (스냅샷 형태)
-        String thumbnailUrl = extractThumbnailUrl(savedAuction);
-        String sellerName = userPort.getNicknamesByIds(Set.of(sellerId)).getOrDefault(sellerId, null);
-        AuctionItemCreatedEvent itemCreatedEvent = new AuctionItemCreatedEvent(
-                savedAuction.getId(),
-                sellerId,
-                sellerName,
-                savedAuction.getTitle(),
-                savedAuction.getDescription(),
-                savedAuction.getCategory().toString(),
-                savedAuction.getStatus().toString(),
-                savedAuction.getStartPrice(),
-                savedAuction.getCurrentPrice(),
-                savedAuction.getBuyNowPrice(),
-                savedAuction.getBuyNowEnabled(),
-                savedAuction.getAuctionStartTime(),
-                savedAuction.getAuctionEndTime(),
-                thumbnailUrl,
-                savedAuction.getCreatedAt(),
-                savedAuction.getUpdatedAt(),
-                savedAuction.getViewCount(),
-                savedAuction.getBidCount(),
-                savedAuction.getWatchlistCount()
-        );
-        if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
-            outboxService.append(AGGREGATE_TYPE_AUCTION, aggregateId, AuctionEventType.AUCTION_ITEM_CREATED.name(), Map.of("eventType", AuctionEventType.AUCTION_ITEM_CREATED.name(), "aggregateId", aggregateId, "data", itemCreatedEvent));
-        } else {
-            eventPublisher.publish(itemCreatedEvent);
+        /**
+         * 썸네일 URL 추출
+         */
+        private String extractThumbnailUrl(AuctionItem auctionItem) {
+                if (auctionItem.getImages() == null || auctionItem.getImages().isEmpty()) {
+                        return null;
+                }
+                return auctionItem.getImages().stream()
+                                .filter(ItemImage::getIsThumbnail)
+                                .findFirst()
+                                .map(ItemImage::getImageUrl)
+                                .orElseGet(() -> auctionItem.getImages().get(0).getImageUrl()); // 썸네일이 없으면 첫 번째 이미지
         }
-
-        // 5. 경매 ID 반환
-        return savedAuction.getId();
-    }
-    
-    /**
-     * 썸네일 URL 추출
-     */
-    private String extractThumbnailUrl(AuctionItem auctionItem) {
-        if (auctionItem.getImages() == null || auctionItem.getImages().isEmpty()) {
-            return null;
-        }
-        return auctionItem.getImages().stream()
-                .filter(ItemImage::getIsThumbnail)
-                .findFirst()
-                .map(ItemImage::getImageUrl)
-                .orElseGet(() -> auctionItem.getImages().get(0).getImageUrl()); // 썸네일이 없으면 첫 번째 이미지
-    }
 
 }

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionStartUseCase.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionStartUseCase.java
@@ -44,14 +44,17 @@ public class AuctionStartUseCase {
                 auction.getStartPrice(),
                 auction.getAuctionEndTime());
         if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
-            outboxService.append(AGGREGATE_TYPE_AUCTION, aggregateId, AuctionEventType.AUCTION_STARTED.name(), Map.of("eventType", AuctionEventType.AUCTION_STARTED.name(), "aggregateId", aggregateId, "data", startedEvent));
+            outboxService.append(AGGREGATE_TYPE_AUCTION, aggregateId, AuctionEventType.AUCTION_STARTED.name(),
+                    Map.of("eventType", AuctionEventType.AUCTION_STARTED.name(), "aggregateId", aggregateId, "data",
+                            startedEvent));
         } else {
             eventPublisher.publish(startedEvent);
         }
 
         // Search 인덱싱 전용 이벤트 발행 (스냅샷 형태)
         String thumbnailUrl = extractThumbnailUrl(auction);
-        String sellerName = userPort.getNicknamesByIds(Set.of(auction.getSellerId())).getOrDefault(auction.getSellerId(), null);
+        String sellerName = userPort.getNicknamesByIds(Set.of(auction.getSellerId()))
+                .getOrDefault(auction.getSellerId(), null);
         AuctionItemUpdatedEvent itemUpdatedEvent = new AuctionItemUpdatedEvent(
                 auction.getId(),
                 auction.getSellerId(),
@@ -73,7 +76,9 @@ public class AuctionStartUseCase {
                 auction.getBidCount(),
                 auction.getWatchlistCount());
         if (eventPublishingConfig.isAuctionEventsKafkaEnabled()) {
-            outboxService.append(AGGREGATE_TYPE_AUCTION, aggregateId, AuctionEventType.AUCTION_ITEM_UPDATED.name(), Map.of("eventType", AuctionEventType.AUCTION_ITEM_UPDATED.name(), "aggregateId", aggregateId, "data", itemUpdatedEvent));
+            outboxService.append(AGGREGATE_TYPE_AUCTION, aggregateId, AuctionEventType.AUCTION_ITEM_UPDATED.name(),
+                    Map.of("eventType", AuctionEventType.AUCTION_ITEM_UPDATED.name(), "aggregateId", aggregateId,
+                            "data", itemUpdatedEvent));
         } else {
             eventPublisher.publish(itemUpdatedEvent);
         }

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/domain/entity/AuctionItem.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/domain/entity/AuctionItem.java
@@ -26,68 +26,68 @@ import static jakarta.persistence.GenerationType.IDENTITY;
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AuctionItem extends BaseTimeEntity {
-    
+
     @Id
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
-    
+
     @Column(nullable = false)
     private Long sellerId;
-    
+
     @Column(nullable = false, length = 255)
     private String title;
-    
+
     @Column(columnDefinition = "TEXT")
     private String description;
-    
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private Category category;
-    
+
     @Column(nullable = false, precision = 19, scale = 2)
     private BigDecimal startPrice;
-    
+
     @Builder.Default
     @Column(nullable = false)
     private Integer bidUnit = 1000;
-    
+
     // 즉시구매 관련 필드
     @Column(precision = 19, scale = 2)
     private BigDecimal buyNowPrice;
-    
+
     @Builder.Default
     @Column(nullable = false)
     private Boolean buyNowEnabled = false;
-    
+
     @Column(nullable = false)
     private LocalDateTime auctionStartTime;
-    
+
     @Column(nullable = false)
     private LocalDateTime auctionEndTime;
-    
+
     @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AuctionStatus status = AuctionStatus.SCHEDULED;
-    
+
     @Column(precision = 19, scale = 2)
     private BigDecimal currentPrice;
-    
+
     @Builder.Default
     private Long viewCount = 0L;
-    
+
     @Builder.Default
     private Integer watchlistCount = 0;
-    
+
     @Builder.Default
     private Integer bidCount = 0;
-    
+
     @Builder.Default
     private Integer extensionCount = 0;
 
     // 즉시구매 악용 방지 (이중 제한) - ORDER_PAYMENT_POLICY.md 참고
     @Builder.Default
-    private Integer buyNowRecoveryCount = 0;       // 즉시구매 미결제 복구 횟수 (경매당)
+    private Integer buyNowRecoveryCount = 0; // 즉시구매 미결제 복구 횟수 (경매당)
 
     @Builder.Default
     private Boolean buyNowDisabledByPolicy = false; // 3진 아웃 시 즉시구매 영구 비활성화
@@ -95,9 +95,9 @@ public class AuctionItem extends BaseTimeEntity {
     @OneToMany(mappedBy = "auctionItem", cascade = ALL, orphanRemoval = true)
     @Builder.Default
     private List<ItemImage> images = new ArrayList<>();
-    
+
     // ==================== 비즈니스 메서드 ====================
-    
+
     /**
      * 경매 생성 정적 팩토리 메서드
      * 비즈니스 규칙 검증 후 엔티티 생성
@@ -112,20 +112,19 @@ public class AuctionItem extends BaseTimeEntity {
             BigDecimal buyNowPrice,
             Boolean buyNowEnabled,
             LocalDateTime auctionStartTime,
-            LocalDateTime auctionEndTime
-    ) {
+            LocalDateTime auctionEndTime) {
         // 1. 필수 필드 검증
         validateRequired(sellerId, title, Category.valueOf(category), startPrice, auctionStartTime, auctionEndTime);
-        
+
         // 2. 시작가 검증
         validateStartPrice(startPrice);
-        
+
         // 3. 경매 기간 검증
         validateAuctionPeriod(auctionStartTime, auctionEndTime);
-        
+
         // 4. 즉시구매가 검증
         validateBuyNowPrice(buyNowEnabled, buyNowPrice, startPrice);
-        
+
         // 5. 엔티티 생성
         return AuctionItem.builder()
                 .sellerId(sellerId)
@@ -149,7 +148,7 @@ public class AuctionItem extends BaseTimeEntity {
                 .images(new ArrayList<>())
                 .build();
     }
-    
+
     /**
      * 경매 정보 수정
      * SCHEDULED 또는 ACTIVE 상태에서만 수정 가능
@@ -158,13 +157,12 @@ public class AuctionItem extends BaseTimeEntity {
             String title,
             String description,
             BigDecimal buyNowPrice,
-            Boolean buyNowEnabled
-    ) {
+            Boolean buyNowEnabled) {
         // 수정 가능 상태 검증
         if (this.status != AuctionStatus.SCHEDULED && this.status != AuctionStatus.ACTIVE) {
             throw new BusinessException(ErrorCode.AUCTION_NOT_MODIFIABLE);
         }
-        
+
         // 필드 업데이트
         if (title != null && !title.isBlank()) {
             this.title = title;
@@ -172,7 +170,7 @@ public class AuctionItem extends BaseTimeEntity {
         if (description != null) {
             this.description = description;
         }
-        
+
         // 즉시구매가 업데이트 (검증 포함)
         if (buyNowEnabled != null && buyNowEnabled) {
             if (buyNowPrice == null) {
@@ -188,7 +186,7 @@ public class AuctionItem extends BaseTimeEntity {
             this.buyNowPrice = null;
         }
     }
-    
+
     /**
      * 경매 시작 (SCHEDULED → ACTIVE)
      * 서버 타임존과 무관하게 한국 시간(KST) 기준으로 비교.
@@ -203,7 +201,7 @@ public class AuctionItem extends BaseTimeEntity {
         }
         this.status = AuctionStatus.ACTIVE;
     }
-    
+
     /**
      * 경매 종료 (ACTIVE → ENDED)
      */
@@ -211,10 +209,10 @@ public class AuctionItem extends BaseTimeEntity {
         if (this.status != AuctionStatus.ACTIVE) {
             throw new BusinessException(ErrorCode.AUCTION_NOT_MODIFIABLE);
         }
-        
+
         this.status = AuctionStatus.ENDED;
     }
-    
+
     /**
      * 낙찰 완료 (ENDED → SOLD)
      * 입찰을 통한 낙찰
@@ -223,10 +221,10 @@ public class AuctionItem extends BaseTimeEntity {
         if (this.status != AuctionStatus.ENDED) {
             throw new BusinessException(ErrorCode.AUCTION_NOT_MODIFIABLE);
         }
-        
+
         this.status = AuctionStatus.SOLD;
     }
-    
+
     /**
      * 경매 취소 (SCHEDULED 또는 ACTIVE → CANCELLED)
      * 입찰이 없는 경우에만 가능
@@ -235,15 +233,15 @@ public class AuctionItem extends BaseTimeEntity {
         if (this.status != AuctionStatus.SCHEDULED && this.status != AuctionStatus.ACTIVE) {
             throw new BusinessException(ErrorCode.AUCTION_NOT_MODIFIABLE);
         }
-        
+
         // 입찰이 있으면 취소 불가
         if (this.bidCount > 0) {
             throw new BusinessException(ErrorCode.AUCTION_NOT_MODIFIABLE);
         }
-        
+
         this.status = AuctionStatus.CANCELLED;
     }
-    
+
     /**
      * 경매 자동 연장
      * 종료 시간 N분 연장
@@ -252,32 +250,32 @@ public class AuctionItem extends BaseTimeEntity {
         if (this.status != AuctionStatus.ACTIVE) {
             throw new BusinessException(ErrorCode.AUCTION_NOT_MODIFIABLE);
         }
-        
+
         this.auctionEndTime = this.auctionEndTime.plusMinutes(minutes);
         this.extensionCount++;
     }
-    
+
     /**
      * 연장 횟수 조회
      */
     public Integer getExtensionCount() {
         return this.extensionCount;
     }
-    
+
     /**
      * 조회수 증가
      */
     public void increaseViewCount() {
         this.viewCount++;
     }
-    
+
     /**
      * 입찰 수 증가
      */
     public void increaseBidCount() {
         this.bidCount++;
     }
-    
+
     /**
      * 현재가 업데이트
      * 입찰 시 호출
@@ -286,10 +284,10 @@ public class AuctionItem extends BaseTimeEntity {
         if (newPrice == null || newPrice.compareTo(BigDecimal.ZERO) <= 0) {
             throw new BusinessException(ErrorCode.AUCTION_INVALID_PRICE);
         }
-        
+
         this.currentPrice = newPrice;
     }
-    
+
     /**
      * 즉시구매 실행 (ACTIVE → SOLD_BY_BUY_NOW)
      * 즉시구매 시 경매 즉시 종료
@@ -308,12 +306,12 @@ public class AuctionItem extends BaseTimeEntity {
         if (this.status != AuctionStatus.ACTIVE) {
             throw new BusinessException(ErrorCode.AUCTION_NOT_ACTIVE);
         }
-        
+
         // 상태 변경
         this.status = AuctionStatus.SOLD_BY_BUY_NOW;
         this.currentPrice = this.buyNowPrice;
     }
-    
+
     /**
      * 낙찰자 미결제 시 유찰 처리 (SOLD → FAIL)
      * 24시간 내 결제하지 않아 주문이 취소된 경우 호출
@@ -351,9 +349,10 @@ public class AuctionItem extends BaseTimeEntity {
         // null-safe (기존 DB 마이그레이션 시 호환)
         int currentCount = (this.buyNowRecoveryCount != null ? this.buyNowRecoveryCount : 0);
 
-        // 종료 시각 지났으면 연장 (Soft Closing)
-        if (LocalDateTime.now().isAfter(this.auctionEndTime)) {
-            this.auctionEndTime = LocalDateTime.now().plusMinutes(extendMinutes);
+        // 종료 시각 지났으면 연장 (Soft Closing) — KST 기준 비교
+        LocalDateTime nowKst = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+        if (nowKst.isAfter(this.auctionEndTime)) {
+            this.auctionEndTime = nowKst.plusMinutes(extendMinutes);
             currentCount++;
             this.buyNowRecoveryCount = currentCount;
         }
@@ -363,7 +362,7 @@ public class AuctionItem extends BaseTimeEntity {
             this.buyNowDisabledByPolicy = true;
         }
     }
-    
+
     /**
      * 장바구니 담기 가능 여부 확인
      * 조건: 즉시구매 활성화 + ACTIVE 상태 + 정책에 의해 비활성화되지 않음
@@ -374,27 +373,26 @@ public class AuctionItem extends BaseTimeEntity {
                 && this.buyNowPrice != null
                 && !Boolean.TRUE.equals(this.buyNowDisabledByPolicy);
     }
-    
+
     /**
      * 입찰 가능 여부 확인
      */
     public boolean canBid() {
         return this.status == AuctionStatus.ACTIVE;
     }
-    
+
     // ==================== 검증 메서드 (private) ====================
-    
+
     /**
      * 필수 필드 검증
      */
     private static void validateRequired(
-            Long sellerId, 
-            String title, 
-            Category category, 
+            Long sellerId,
+            String title,
+            Category category,
             BigDecimal startPrice,
-            LocalDateTime auctionStartTime, 
-            LocalDateTime auctionEndTime
-    ) {
+            LocalDateTime auctionStartTime,
+            LocalDateTime auctionEndTime) {
         if (sellerId == null || sellerId <= 0) {
             throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE);
         }
@@ -411,7 +409,7 @@ public class AuctionItem extends BaseTimeEntity {
             throw new BusinessException(ErrorCode.AUCTION_INVALID_DURATION);
         }
     }
-    
+
     /**
      * 시작가 검증
      * 최소 1,000원 이상
@@ -421,7 +419,7 @@ public class AuctionItem extends BaseTimeEntity {
             throw new BusinessException(ErrorCode.AUCTION_INVALID_PRICE);
         }
     }
-    
+
     /**
      * 경매 기간 검증
      * 최소 1시간 ~ 최대 30일
@@ -431,23 +429,23 @@ public class AuctionItem extends BaseTimeEntity {
         if (endTime.isBefore(startTime) || endTime.isEqual(startTime)) {
             throw new BusinessException(ErrorCode.AUCTION_INVALID_DURATION);
         }
-        
+
         // 경매 기간 계산
         Duration duration = Duration.between(startTime, endTime);
         long hours = duration.toHours();
         long days = duration.toDays();
-        
+
         // 최소 1시간
         if (hours < AuctionPolicy.MIN_AUCTION_DURATION_HOURS) {
             throw new BusinessException(ErrorCode.AUCTION_INVALID_DURATION);
         }
-        
+
         // 최대 30일
         if (days > AuctionPolicy.MAX_AUCTION_DURATION_DAYS) {
             throw new BusinessException(ErrorCode.AUCTION_INVALID_DURATION);
         }
     }
-    
+
     /**
      * 즉시구매가 검증
      * 즉시구매 활성화 시: buyNowPrice 필수, 시작가보다 높아야 함
@@ -458,7 +456,7 @@ public class AuctionItem extends BaseTimeEntity {
             if (buyNowPrice == null) {
                 throw new BusinessException(ErrorCode.BUY_NOW_PRICE_NOT_SET);
             }
-            
+
             // 즉시구매가는 시작가보다 높아야 함
             if (buyNowPrice.compareTo(startPrice) <= 0) {
                 throw new BusinessException(ErrorCode.AUCTION_INVALID_PRICE);

--- a/fourtune/auction-service/src/main/resources/application.yml
+++ b/fourtune/auction-service/src/main/resources/application.yml
@@ -11,6 +11,10 @@ spring:
     hibernate:
       ddl-auto: update
     open-in-view: false
+    properties:
+      hibernate:
+        jdbc:
+          time_zone: Asia/Seoul
   datasource:
     url: ${DB_URL:jdbc:postgresql://localhost:5432/auction}
     username: ${DB_USERNAME:fourtune_user}

--- a/fourtune/auction-service/src/test/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionCloseUseCaseTest.java
+++ b/fourtune/auction-service/src/test/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionCloseUseCaseTest.java
@@ -1,0 +1,165 @@
+package com.fourtune.auction.boundedContext.auction.application.service;
+
+import com.fourtune.auction.boundedContext.auction.domain.constant.AuctionStatus;
+import com.fourtune.auction.boundedContext.auction.domain.constant.Category;
+import com.fourtune.auction.boundedContext.auction.domain.entity.AuctionItem;
+import com.fourtune.auction.boundedContext.auction.domain.entity.Bid;
+import com.fourtune.auction.port.out.UserPort;
+import com.fourtune.core.config.EventPublishingConfig;
+import com.fourtune.core.eventPublisher.EventPublisher;
+import com.fourtune.outbox.service.OutboxService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.*;
+
+/**
+ * AuctionCloseUseCase 단위 테스트.
+ * 핵심 검증:
+ * - Feign 실패 시 낙찰/종료 상태 전환이 롤백되지 않음
+ * - validateCloseable()이 KST 기준으로 동작하는지 확인
+ */
+@ExtendWith(MockitoExtension.class)
+class AuctionCloseUseCaseTest {
+
+    @Mock AuctionSupport auctionSupport;
+    @Mock BidSupport bidSupport;
+    @Mock OrderCreateUseCase orderCreateUseCase;
+    @Mock EventPublisher eventPublisher;
+    @Mock UserPort userPort;
+    @Mock EventPublishingConfig eventPublishingConfig;
+    @Mock OutboxService outboxService;
+
+    @InjectMocks
+    AuctionCloseUseCase sut;
+
+    // ==================== Feign 장애 복원력 — 낙찰자 있는 경우 ====================
+
+    @Test
+    @DisplayName("낙찰자 있음 + Feign 정상 — SOLD 저장 및 Outbox 2건 발행")
+    void closeAuction_withWinner_feignSuccess_savesSold() {
+        AuctionItem auction = buildActiveAuction(1L);
+        Bid winningBid = buildBid(1L, 2L, BigDecimal.valueOf(20_000));
+
+        when(auctionSupport.findByIdWithLockOrThrow(1L)).thenReturn(auction);
+        when(bidSupport.findHighestBid(1L)).thenReturn(Optional.of(winningBid));
+        when(orderCreateUseCase.createWinningOrder(any(AuctionItem.class), any(), any())).thenReturn("ORDER-001");
+        when(userPort.getNicknamesByIds(any())).thenReturn(java.util.Map.of(1L, "판매자"));
+        when(eventPublishingConfig.isAuctionEventsKafkaEnabled()).thenReturn(true);
+
+        sut.closeAuction(1L);
+
+        verify(auctionSupport).findByIdWithLockOrThrow(1L);
+        verify(outboxService, times(2)).append(any(), any(), any(), any());
+        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.SOLD);
+    }
+
+    @Test
+    @DisplayName("낙찰자 있음 + Feign 타임아웃 — 예외 전파 없이 낙찰 처리 완료")
+    void closeAuction_withWinner_feignTimeout_doesNotThrow() {
+        AuctionItem auction = buildActiveAuction(1L);
+        Bid winningBid = buildBid(1L, 2L, BigDecimal.valueOf(20_000));
+
+        when(auctionSupport.findByIdWithLockOrThrow(1L)).thenReturn(auction);
+        when(bidSupport.findHighestBid(1L)).thenReturn(Optional.of(winningBid));
+        when(orderCreateUseCase.createWinningOrder(any(AuctionItem.class), any(), any())).thenReturn("ORDER-001");
+        when(userPort.getNicknamesByIds(any())).thenThrow(new RuntimeException("Feign read timeout"));
+        when(eventPublishingConfig.isAuctionEventsKafkaEnabled()).thenReturn(true);
+
+        // Feign 실패해도 예외가 전파되지 않아야 한다
+        assertThatCode(() -> sut.closeAuction(1L)).doesNotThrowAnyException();
+
+        // 낙찰 상태로 저장되었는지 확인
+        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.SOLD);
+        // Outbox는 AuctionClosedEvent + AuctionItemUpdatedEvent(sellerName=null) 2건
+        verify(outboxService, times(2)).append(any(), any(), any(), any());
+    }
+
+    // ==================== Feign 장애 복원력 — 낙찰자 없는 경우 ====================
+
+    @Test
+    @DisplayName("낙찰자 없음 + Feign 타임아웃 — 예외 전파 없이 ENDED 처리 완료")
+    void closeAuction_noWinner_feignTimeout_doesNotThrow() {
+        AuctionItem auction = buildActiveAuction(1L);
+
+        when(auctionSupport.findByIdWithLockOrThrow(1L)).thenReturn(auction);
+        when(bidSupport.findHighestBid(1L)).thenReturn(Optional.empty());
+        when(userPort.getNicknamesByIds(any())).thenThrow(new RuntimeException("fourtune-api down"));
+        when(eventPublishingConfig.isAuctionEventsKafkaEnabled()).thenReturn(true);
+
+        assertThatCode(() -> sut.closeAuction(1L)).doesNotThrowAnyException();
+
+        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.ENDED);
+        verify(outboxService, times(2)).append(any(), any(), any(), any());
+    }
+
+    // ==================== validateCloseable KST 검증 ====================
+
+    @Test
+    @DisplayName("validateCloseable — 종료 시각이 이미 지난 ACTIVE 경매는 정상 처리된다")
+    void closeAuction_pastEndTime_processesSuccessfully() {
+        // auctionEndTime을 KST 기준 과거로 설정
+        AuctionItem auction = buildActiveAuctionWithEndTime(
+                1L, LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(5)
+        );
+
+        when(auctionSupport.findByIdWithLockOrThrow(1L)).thenReturn(auction);
+        when(bidSupport.findHighestBid(1L)).thenReturn(Optional.empty());
+        when(userPort.getNicknamesByIds(any())).thenReturn(java.util.Map.of());
+        when(eventPublishingConfig.isAuctionEventsKafkaEnabled()).thenReturn(true);
+
+        assertThatCode(() -> sut.closeAuction(1L)).doesNotThrowAnyException();
+        assertThat(auction.getStatus()).isEqualTo(AuctionStatus.ENDED);
+    }
+
+    // ==================== 헬퍼 ====================
+
+    private AuctionItem buildActiveAuction(Long id) {
+        return buildActiveAuctionWithEndTime(
+                id, LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusMinutes(1)
+        );
+    }
+
+    private AuctionItem buildActiveAuctionWithEndTime(Long id, LocalDateTime endTime) {
+        return AuctionItem.builder()
+                .id(id)
+                .sellerId(1L)
+                .title("테스트 경매")
+                .description("설명")
+                .category(Category.ETC)
+                .startPrice(BigDecimal.valueOf(10_000))
+                .bidUnit(1000)
+                .buyNowEnabled(false)
+                .buyNowPrice(null)
+                .auctionStartTime(LocalDateTime.now(ZoneId.of("Asia/Seoul")).minusHours(2))
+                .auctionEndTime(endTime)
+                .status(AuctionStatus.ACTIVE)
+                .currentPrice(BigDecimal.valueOf(10_000))
+                .viewCount(0L)
+                .watchlistCount(0)
+                .bidCount(0)
+                .extensionCount(0)
+                .buyNowRecoveryCount(0)
+                .buyNowDisabledByPolicy(false)
+                .images(new ArrayList<>())
+                .build();
+    }
+
+    private Bid buildBid(Long auctionId, Long bidderId, BigDecimal amount) {
+        return Bid.create(auctionId, bidderId, amount, BigDecimal.valueOf(10_000), 1000, false);
+    }
+}

--- a/fourtune/common/shared/src/main/java/com/fourtune/shared/auction/dto/AuctionItemCreateRequest.java
+++ b/fourtune/common/shared/src/main/java/com/fourtune/shared/auction/dto/AuctionItemCreateRequest.java
@@ -9,15 +9,14 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record AuctionItemCreateRequest(
-    @NotBlank String title,
-    String description,
-    @NotNull String category,
-    @NotNull @Min(1000) BigDecimal startPrice,
-    @Min(1000) Integer bidUnit,
-    BigDecimal buyNowPrice,
-    @NotNull LocalDateTime auctionStartTime,
-    @NotNull LocalDateTime auctionEndTime,
-    List<String> imageUrls
-) {
+        @NotBlank String title,
+        String description,
+        @NotNull String category,
+        @NotNull @Min(1000) BigDecimal startPrice,
+        @Min(1000) Integer bidUnit,
+        BigDecimal buyNowPrice,
+        @NotNull LocalDateTime auctionStartTime,
+        @NotNull LocalDateTime auctionEndTime,
+        List<String> imageUrls) {
     // TODO: sellerId 추가 메서드
 }

--- a/fourtune/common/shared/src/main/java/com/fourtune/shared/auction/dto/AuctionItemUpdateRequest.java
+++ b/fourtune/common/shared/src/main/java/com/fourtune/shared/auction/dto/AuctionItemUpdateRequest.java
@@ -4,13 +4,12 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 public record AuctionItemUpdateRequest(
-    String title,
-    String description,
-    String category,
-    BigDecimal startPrice,
-    Integer bidUnit,
-    BigDecimal buyNowPrice,
-    LocalDateTime auctionStartTime,
-    LocalDateTime auctionEndTime
-) {
+                String title,
+                String description,
+                String category,
+                BigDecimal startPrice,
+                Integer bidUnit,
+                BigDecimal buyNowPrice,
+                LocalDateTime auctionStartTime,
+                LocalDateTime auctionEndTime) {
 }


### PR DESCRIPTION
# 📌 개요

1. `userPort.getNicknamesByIds()` Feign 호출이 `REQUIRES_NEW` 트랜잭션 내부에 위치하여,
   fourtune-api 일시 장애 시 경매 상태 전환 전체가 롤백됨
2. 코드 전반에 `LocalDateTime.now()` (bare) 사용으로 TZ 환경변수 미설정 시 9시간 오차 발생

## 👩‍💻 작업 사항

**[P0] Feign 장애 격리**
- [x] `AuctionStartUseCase` — `getNicknamesByIds()` try-catch 격리 (ACTIVE 전환 보호)
- [x] `AuctionCloseUseCase` — `getNicknamesByIds()` try-catch 격리 (낙찰 처리 보호)
- [x] `AuctionBuyNowUseCase` — `getNicknamesByIds()` try-catch 격리 (즉시구매 보호)
- [x] `BidPlaceUseCase` — `getNicknamesByIds()` try-catch 격리 (입찰 저장 보호)
- [x] `FeignConfig` — connectTimeout(2s) / readTimeout(3s) / 재시도(2회) 추가

**[P0] KST 타임존 명시**
- [x] `OrderScheduler` — 주문 만료 cutoff 계산을 `LocalDateTime.now(ZoneId.of("Asia/Seoul"))` 로 수정
- [x] `BidPlaceUseCase` — `validateBidPlaceable()`, `checkAndExtendAuction()` KST 수정
- [x] `AuctionCloseUseCase` — `validateCloseable()` KST 수정
- [x] `AuctionItem` — `recoverFromBuyNowFailure()` KST 수정
- [x] `AuctionBuyNowUseCase`, `BidPlaceUseCase` — 이벤트 타임스탬프 KST 수정

**[P1] 인프라 타임존 보강**
- [x] `Dockerfile` — `-Duser.timezone=Asia/Seoul` JVM 옵션 추가 (K8s/CI 환경 대응)
- [x] `application.yml` — `hibernate.jdbc.time_zone: Asia/Seoul` 추가


## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
