### PR TITLE
chore: 검색 결과 NPE 방어 로직 추가

### DIFF
--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/ElasticsearchAuctionItemSearchEngine.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/ElasticsearchAuctionItemSearchEngine.java
@@ -223,9 +223,9 @@ public class ElasticsearchAuctionItemSearchEngine implements AuctionItemSearchEn
                 d.getUpdatedAt() != null
                         ? d.getUpdatedAt().withZoneSameInstant(ZoneId.of("Asia/Seoul")).toLocalDateTime()
                         : null,
-                d.getViewCount(),
-                d.getWatchlistCount(),
-                d.getBidCount(),
+                d.getViewCount() != null ? d.getViewCount() : 0L,
+                d.getWatchlistCount() != null ? d.getWatchlistCount() : 0,
+                d.getBidCount() != null ? d.getBidCount() : 0,
                 d.getSellerId(),
                 d.getSellerName());
     }


### PR DESCRIPTION
## 📌 개요
- 최근 경매 아이템 검색 기능에서 특정 정렬(예: 최신순)로 조회 시 간헐적으로 `500 Internal Server Error`가 발생하는 문제가 발견되었습니다.

분석 결과, Elasticsearch에 저장된 문서의 수치 필드(`viewCount`, `watchlistCount`, `bidCount`)가 `null`일 때, 이를 서비스 계층에서 사용하는 SearchAuctionItemView(Java Record)의 기본형(`long`, `int`) 필드로 변환하는 과정에서 **자동 언박싱(Auto-unboxing)에 의한 NullPointerException**이 발생하고 있습니다.

특히 새로 등록된 경매 아이템들이 인덱싱될 때 초기값이 `null`로 설정된 경우, 해당 아이템이 검색 결과 첫 페이지에 나타나면서 전체 검색 API가 실패하게 됩니다. 이에 대한 전역적인 null 방어 로직 적용이 필요합니다.

## 👩‍💻 작업 사항
- [x] [toView()] 메서드의 NPE 발생 지점 분석 
- [x] 검색 엔진 및 리스너 코드 검토 및 수정

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #390
