### PR TITLE
fix: @EnableScheduling 누락으로 결제 완료 이벤트 미발행 버그 수정

### DIFF
--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/kafka/PaymentResultKafkaListener.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/kafka/PaymentResultKafkaListener.java
@@ -2,6 +2,7 @@ package com.fourtune.auction.boundedContext.auction.adapter.in.kafka;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fourtune.auction.boundedContext.auction.application.service.OrderCompleteUseCase;
+import com.fourtune.core.error.exception.BusinessException;
 import com.fourtune.kafka.KafkaTopicConfig;
 import com.fourtune.shared.payment.event.PaymentCanceledEvent;
 import com.fourtune.shared.payment.event.PaymentFailedEvent;
@@ -73,6 +74,9 @@ public class PaymentResultKafkaListener {
                     log.warn("PAYMENT_FAILED 수신했으나 order 정보 없음: key={}", key);
                 }
             }
+        } catch (BusinessException e) {
+            // 이미 처리된 주문 등 비즈니스 예외는 재시도 없이 무시 (멱등성 보장)
+            log.warn("Payment 결과 처리 중 비즈니스 예외 (재시도 안 함): eventType={}, key={}, error={}", eventType, key, e.getMessage());
         } catch (Exception e) {
             log.error("Payment 결과 처리 실패: eventType={}, key={}, error={}", eventType, key, e.getMessage(), e);
             throw new RuntimeException("Payment 결과 처리 실패", e);

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/ApiV1OrderController.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/ApiV1OrderController.java
@@ -86,6 +86,19 @@ public class ApiV1OrderController {
     }
     
     /**
+     * 결제 재시도용 orderId 갱신
+     * Toss는 한 번 사용된 orderId 재사용 불가 → 결제 실패 후 재시도 시 새 orderId 발급
+     */
+    @PostMapping("/{orderId}/renew-payment-id")
+    public ResponseEntity<ApiResponse<String>> renewPaymentId(
+            @AuthenticationPrincipal UserContext user,
+            @PathVariable String orderId
+    ) {
+        String newOrderId = orderCompleteUseCase.renewPaymentId(orderId, user.id());
+        return ResponseEntity.ok(ApiResponse.success(newOrderId));
+    }
+
+    /**
      * 결제 완료 처리 (Payment 도메인에서 호출)
      * 내부 API - 별도 인증 처리 필요
      */

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/domain/entity/Order.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/domain/entity/Order.java
@@ -167,6 +167,18 @@ public class Order extends BaseTimeEntity {
         return this.status == OrderStatus.CANCELLED;
     }
 
+    /**
+     * 결제 재시도를 위한 orderId 갱신 (PENDING 상태에서만 허용)
+     * Toss는 한 번 사용된 orderId를 재사용 불허하므로, 결제 실패 후 재시도 시 새 orderId 필요
+     */
+    public String renewOrderId() {
+        if (this.status != OrderStatus.PENDING) {
+            throw new BusinessException(ErrorCode.ORDER_ALREADY_PROCESSED);
+        }
+        this.orderId = generateOrderId();
+        return this.orderId;
+    }
+
     // ==================== 검증 메서드 (private) ====================
     
     /**

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/port/out/OrderRepository.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/port/out/OrderRepository.java
@@ -20,8 +20,15 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     Optional<Order> findByOrderId(String orderId);
     
     /**
-     * 경매 ID로 주문 조회
+     * 경매 ID로 주문 조회 (취소되지 않은 가장 최근 주문)
+     * CANCELLED 이후 재주문이 허용되므로 여러 주문이 존재할 수 있음 → 활성 주문 우선 반환
      */
+    Optional<Order> findFirstByAuctionIdAndStatusNotOrderByCreatedAtDesc(Long auctionId, OrderStatus status);
+
+    /**
+     * @deprecated 여러 주문 존재 시 NonUniqueResultException 발생 → findFirstByAuctionIdAndStatusNotOrderByCreatedAtDesc 사용
+     */
+    @Deprecated
     Optional<Order> findByAuctionId(Long auctionId);
     
     /**
@@ -92,9 +99,15 @@ public interface OrderRepository extends JpaRepository<Order, Long> {
     );
     
     /**
-     * 경매에 주문이 이미 존재하는지 확인
+     * 경매에 주문이 이미 존재하는지 확인 (모든 상태 포함)
      */
     boolean existsByAuctionId(Long auctionId);
+
+    /**
+     * 경매에 활성 주문(PENDING/COMPLETED)이 존재하는지 확인
+     * CANCELLED 주문은 제외 - 취소 후 재주문 허용을 위해
+     */
+    boolean existsByAuctionIdAndStatusNot(Long auctionId, OrderStatus status);
     
     /**
      * orderId 존재 여부 확인

--- a/fourtune/docker-compose.yml
+++ b/fourtune/docker-compose.yml
@@ -225,6 +225,12 @@ services:
         condition: service_healthy
     networks:
       - fourtune-network
+    healthcheck:
+      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8081/actuator/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 90s
 
   # auction-service (경매 MSA — 8083, 호스트 9081)
   # 경매 시작/종료 시각 비교를 한국 시간 기준으로 통일 (프론트 KST 전송과 맞춤)

--- a/fourtune/nginx/nginx.dev.conf
+++ b/fourtune/nginx/nginx.dev.conf
@@ -41,7 +41,7 @@ http {
 
     # Upstream: 결제 서비스 (payment-service)
     upstream payment {
-        server payment-service:8080 max_fails=3 fail_timeout=30s;
+        server payment-service:8081 max_fails=3 fail_timeout=30s;
     }
 
     # Upstream: 추천 서비스 (recommendation-service)

--- a/fourtune/payment-service/src/main/java/com/fourtune/PaymentApplication.java
+++ b/fourtune/payment-service/src/main/java/com/fourtune/PaymentApplication.java
@@ -5,11 +5,15 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableFeignClients(basePackages = "com.fourtune")
 @SpringBootApplication(scanBasePackages = "com.fourtune")
 @EnableJpaRepositories(basePackages = "com.fourtune")
 @EntityScan(basePackages = "com.fourtune")
+@EnableScheduling
+@EnableJpaAuditing
 public class PaymentApplication {
 
     public static void main(String[] args) {


### PR DESCRIPTION
## 📌 개요

- 결제 승인 후 주문이 `PENDING` 상태에서 `COMPLETED`로 전환되지 않는 버그를 수정
- 추가로, 재주문 허용 정책 적용 이후 동일 경매에 복수의 주문이 존재할 때 발생하는
`NonUniqueResultException`과 Kafka 이벤트 중복 처리 시 무한 재시도 버그도 함께 수정

## 👩‍💻 작업 사항
**payment-service**
- [x] `PaymentApplication`에 `@EnableScheduling` 추가 — `OutboxPublisher` 폴링 활성화
- [x] `PaymentApplication`에 `@EnableJpaAuditing` 추가 — `@CreatedDate` 정상 동작
- [x] `PAYMENT_FAILED` Outbox 저장 시 `aggregateId` 타입 오류 수정 (`String` → `Long`)
- [x] Toss `ALREADY_PROCESSING_REQUEST` 응답 수신 시 2초 대기 후 DB 재확인 방어 로직 추가
- [x] nginx `payment-service` upstream 포트 오설정 수정 (`8080` → `8081`)

**auction-service**
- [x] `OrderRepository.findByAuctionId` → `findFirstByAuctionIdAndStatusNotOrderByCreatedAtDesc`로 교체 — CANCELLED 주문 공존 시 `NonUniqueResultException` 방지
- [x] `PaymentResultKafkaListener`에서 `BusinessException` 수신 시 `RuntimeException` 대신 WARN 로그 처리 — Kafka 무한 재시도 방지
- [x] `Order.renewOrderId()` 메서드 추가 — 결제 재시도 시 orderId 갱신
- [x] `OrderCompleteUseCase.renewPaymentId()` 서비스 로직 추가
- [x] `POST /api/v1/orders/{orderId}/renew-payment-id` 엔드포인트 추가

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
