### PR TITLE
feat: 최근 검색어 전체 삭제 기능 도입

### DIFF
--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/adapter/in/web/RecentSearchController.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/adapter/in/web/RecentSearchController.java
@@ -31,10 +31,18 @@ public class RecentSearchController {
     @DeleteMapping
     public ResponseEntity<Void> removeRecentKeyword(
             @AuthenticationPrincipal UserContext user,
-            @RequestParam String keyword
-    ) {
+            @RequestParam String keyword) {
         if (user != null) {
             recentSearchService.removeKeyword(user.id(), keyword);
+        }
+        return ResponseEntity.noContent().build();
+    }
+
+    // 최근 검색어 전체 삭제
+    @DeleteMapping("/all")
+    public ResponseEntity<Void> removeAllRecentKeywords(@AuthenticationPrincipal UserContext user) {
+        if (user != null) {
+            recentSearchService.removeAllKeywords(user.id());
         }
         return ResponseEntity.noContent().build();
     }

--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/application/service/RecentSearchService.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/application/service/RecentSearchService.java
@@ -42,11 +42,11 @@ public class RecentSearchService {
             // 2. 최대 개수 초과 시 오래된 순 삭제
             Long count = zSetOps.zCard(key);
             int maxKeywords = recentSearchPolicy.getMaxKeywords();
-            
+
             if (count != null && count > maxKeywords) {
                 zSetOps.removeRange(key, 0, count - maxKeywords - 1);
             }
-            
+
             // 3. TTL 설정
             redisTemplate.expire(key, recentSearchPolicy.getTtl());
 
@@ -62,7 +62,7 @@ public class RecentSearchService {
         }
         String key = recentSearchPolicy.getKeyPrefix() + userId;
         int maxKeywords = recentSearchPolicy.getMaxKeywords();
-        
+
         // Score 역순(최신순) 조회
         Set<String> keywords = redisTemplate.opsForZSet().reverseRange(key, 0, maxKeywords - 1);
         return keywords != null ? new ArrayList<>(keywords) : Collections.emptyList();
@@ -75,5 +75,14 @@ public class RecentSearchService {
         }
         String key = recentSearchPolicy.getKeyPrefix() + userId;
         redisTemplate.opsForZSet().remove(key, keyword);
+    }
+
+    // 최근 검색어 전체 삭제
+    public void removeAllKeywords(Long userId) {
+        if (userId == null) {
+            return;
+        }
+        String key = recentSearchPolicy.getKeyPrefix() + userId;
+        redisTemplate.delete(key);
     }
 }


### PR DESCRIPTION
## 📌 개요
- 최근 검색어 전체 삭제 엔드포인트 추가

## 👩‍💻 작업 사항
- [x] DELETE /api/v1/search/recent/all 엔드포인트 추가 및 recentSearchService.removeAllKeywords(userId) 연동.

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #395
