### PR TITLE
fix: 마이페이지 입찰 내역에 경매 타이틀 누락 버그 수정

### DIFF
--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionSupport.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionSupport.java
@@ -13,7 +13,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * 경매 공통 조회/검증 기능
@@ -56,6 +59,14 @@ public class AuctionSupport {
      */
     public AuctionItem save(AuctionItem auctionItem) {
         return auctionItemRepository.save(auctionItem);
+    }
+
+    /**
+     * 여러 경매 ID로 경매 제목 맵 조회 (auctionId -> title)
+     */
+    public Map<Long, String> findTitlesByIds(Set<Long> auctionIds) {
+        return auctionItemRepository.findAllById(auctionIds).stream()
+                .collect(Collectors.toMap(AuctionItem::getId, AuctionItem::getTitle));
     }
 
     /**

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/BidQueryUseCase.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/BidQueryUseCase.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -52,8 +53,12 @@ public class BidQueryUseCase {
         List<Bid> bids = bidSupport.findByBidderId(bidderId);
         var nicknames = userPort.getNicknamesByIds(Set.of(bidderId));
         String bidderNickname = nicknames.get(bidderId);
+
+        Set<Long> auctionIds = bids.stream().map(Bid::getAuctionId).collect(Collectors.toSet());
+        Map<Long, String> auctionTitles = auctionSupport.findTitlesByIds(auctionIds);
+
         return bids.stream()
-                .map(bid -> BidMapper.from(bid, bidderNickname))
+                .map(bid -> BidMapper.from(bid, auctionTitles.get(bid.getAuctionId()), bidderNickname))
                 .toList();
     }
 

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/mapper/BidMapper.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/mapper/BidMapper.java
@@ -74,6 +74,7 @@ public class BidMapper {
                                           Map<Long, String> bidderNicknames) {
         List<BidResponse> bidResponses = bids.stream()
                 .map(bid -> BidMapper.from(bid,
+                        auctionItem.getTitle(),
                         bidderNicknames != null ? bidderNicknames.get(bid.getBidderId()) : null))
                 .toList();
         return new BidHistoryResponse(
@@ -91,8 +92,9 @@ public class BidMapper {
         return new BidResponse(
                 bid.getId(),
                 bid.getAuctionId(),
+                null,
                 bid.getBidderId(),
-                null, // bidderNickname은 User 조회 필요 - 나중에 조인 또는 별도 조회
+                null,
                 bid.getBidAmount(),
                 bid.getStatus().toString(),
                 bid.getIsWinning(),
@@ -107,6 +109,24 @@ public class BidMapper {
         return new BidResponse(
                 bid.getId(),
                 bid.getAuctionId(),
+                null,
+                bid.getBidderId(),
+                bidderNickname,
+                bid.getBidAmount(),
+                bid.getStatus().toString(),
+                bid.getIsWinning(),
+                bid.getCreatedAt()
+        );
+    }
+
+    /**
+     * Bid 엔티티 + 경매 타이틀 + 닉네임으로 BidResponse 생성 (마이페이지 입찰 내역용)
+     */
+    public static BidResponse from(Bid bid, String auctionTitle, String bidderNickname) {
+        return new BidResponse(
+                bid.getId(),
+                bid.getAuctionId(),
+                auctionTitle,
                 bid.getBidderId(),
                 bidderNickname,
                 bid.getBidAmount(),

--- a/fourtune/common/shared/src/main/java/com/fourtune/shared/auction/dto/BidResponse.java
+++ b/fourtune/common/shared/src/main/java/com/fourtune/shared/auction/dto/BidResponse.java
@@ -9,6 +9,7 @@ import java.time.LocalDateTime;
 public record BidResponse(
     Long id,
     Long auctionId,
+    String auctionTitle,
     Long bidderId,
     String bidderNickname,
     BigDecimal bidAmount,


### PR DESCRIPTION
## 📌 개요
마이페이지 입찰 내역에서 경매 상품명이 표시되지 않는 버그를 수정

## 👩‍💻 작업 사항
- [x] `BidResponse`: `auctionTitle` 필드 추가
- [x] `BidMapper`: `auctionTitle` 포함 오버로드 `from(bid, auctionTitle, nickname)` 추가
- [x] `AuctionSupport`: `findTitlesByIds()` batch 조회 메서드 추가 (N+1 방지)
- [x] `BidQueryUseCase.getUserBids()`: 경매 타이틀을 batch 조회 후 응답에 포함하도록 수정


## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
