### PR TITLE
fix: 경매 수정 API Content-Type 불일치 및 DB 미반영 버그 수정

### DIFF
--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/ApiV1AuctionController.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/ApiV1AuctionController.java
@@ -60,11 +60,12 @@ public class ApiV1AuctionController {
         return ResponseEntity.ok(response);
     }
     
-    @PutMapping("/{id}")
+    @PutMapping(value = "/{id}", consumes = {"multipart/form-data", "application/json"})
     public ResponseEntity<AuctionItemResponse> updateAuction(
         @AuthenticationPrincipal UserContext user,
         @PathVariable Long id,
-        @RequestBody @Valid AuctionItemUpdateRequest request
+        @RequestPart("request") @Valid AuctionItemUpdateRequest request,
+        @RequestPart(value = "images", required = false) List<MultipartFile> images
     ) {
         Long userId = user.id();
         AuctionItemResponse response = auctionFacade.updateAuction(id, userId, request);

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionUpdateUseCase.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionUpdateUseCase.java
@@ -56,8 +56,9 @@ public class AuctionUpdateUseCase {
                 request.buyNowPrice(),
                 request.buyNowPrice() != null  // buyNowEnabled
         );
-        
-        // 5. DB 저장 (dirty checking으로 자동 저장)
+
+        // 5. DB 저장 (AuctionSupport의 readOnly 트랜잭션 컨텍스트로 dirty checking이 동작하지 않을 수 있어 명시적 save 호출)
+        auctionSupport.save(auctionItem);
         
         // 6. 이벤트 발행
         Long aggregateId = auctionItem.getId();


### PR DESCRIPTION
## 📌 개요
경매 수정 기능이 동작하지 않는 버그를 수정

## 👩‍💻 작업 사항
- [x] `ApiV1AuctionController`: `@RequestBody` → `@RequestPart`로 변경하여
  프론트엔드의 `multipart/form-data` 요청을 정상 처리하도록 수정
- [x] `AuctionUpdateUseCase`: `AuctionSupport`의 `readOnly` 트랜잭션으로 인한
  Hibernate FlushMode MANUAL 설정 문제를 방지하기 위해 명시적 `save()` 호출 추가

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
