### PR TITLE
feat: 내 경매 관리 전용 API 추가 (GET /api/v1/auctions/me)

### DIFF
--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/ApiV1AuctionController.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/adapter/in/web/ApiV1AuctionController.java
@@ -38,6 +38,20 @@ public class ApiV1AuctionController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
     
+    /**
+     * 내 경매 목록 조회 (로그인한 판매자 전용)
+     * GET /api/v1/auctions/me?status=ACTIVE&page=0&size=10
+     */
+    @GetMapping("/me")
+    public ResponseEntity<Page<AuctionItemResponse>> getMyAuctions(
+        @AuthenticationPrincipal UserContext user,
+        @RequestParam(required = false) AuctionStatus status,
+        Pageable pageable
+    ) {
+        Page<AuctionItemResponse> response = auctionFacade.getMyAuctions(user.id(), status, pageable);
+        return ResponseEntity.ok(response);
+    }
+
     @GetMapping
     public ResponseEntity<Page<AuctionItemResponse>> getAuctionList(
         @RequestParam(required = false) AuctionStatus status,

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionFacade.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionFacade.java
@@ -157,6 +157,17 @@ public class AuctionFacade {
     }
 
     /**
+     * 내 경매 목록 조회 (로그인한 판매자 전용)
+     */
+    @Transactional(readOnly = true)
+    public Page<AuctionItemResponse> getMyAuctions(
+            Long sellerId,
+            com.fourtune.auction.boundedContext.auction.domain.constant.AuctionStatus status,
+            Pageable pageable) {
+        return auctionQueryUseCase.getSellerAuctions(sellerId, status, pageable);
+    }
+
+    /**
      * 경매 목록 조회 (필터링)
      */
     @Transactional(readOnly = true)
@@ -183,7 +194,7 @@ public class AuctionFacade {
      */
     @Transactional(readOnly = true)
     public Page<AuctionItemResponse> getSellerAuctions(Long sellerId, Pageable pageable) {
-        Page<AuctionItemResponse> page = auctionQueryUseCase.getSellerAuctions(sellerId, pageable);
+        Page<AuctionItemResponse> page = auctionQueryUseCase.getSellerAuctions(sellerId, null, pageable);
         if (viewCountUseRedis && !page.isEmpty()) {
             List<AuctionItemResponse> content = page.getContent();
             List<Long> ids = content.stream().map(AuctionItemResponse::id).toList();

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionQueryUseCase.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionQueryUseCase.java
@@ -83,15 +83,18 @@ public class AuctionQueryUseCase {
     }
 
     /**
-     * 판매자의 경매 목록 조회
+     * 판매자의 경매 목록 조회 (내 경매 관리용)
+     * status가 null이면 전체 조회, 있으면 해당 상태만 필터링
      */
-    public Page<AuctionItemResponse> getSellerAuctions(Long sellerId, Pageable pageable) {
-        // 1. 판매자의 경매 목록 조회
+    public Page<AuctionItemResponse> getSellerAuctions(
+            Long sellerId,
+            com.fourtune.auction.boundedContext.auction.domain.constant.AuctionStatus status,
+            Pageable pageable) {
         Page<com.fourtune.auction.boundedContext.auction.domain.entity.AuctionItem> auctionPage =
-                auctionSupport.findBySellerIdPaged(sellerId, pageable);
-        // 2. 판매자 닉네임 조회 (동일 판매자)
+                (status != null)
+                        ? auctionSupport.findBySellerIdAndStatusPaged(sellerId, status, pageable)
+                        : auctionSupport.findBySellerIdPaged(sellerId, pageable);
         String sellerNickname = userPort.getNicknamesByIds(Set.of(sellerId)).get(sellerId);
-        // 3. DTO 변환 후 반환
         return auctionPage.map(item -> AuctionMapper.from(item, sellerNickname));
     }
 

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionSupport.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/application/service/AuctionSupport.java
@@ -107,6 +107,10 @@ public class AuctionSupport {
         return auctionItemRepository.findBySellerIdOrderByCreatedAtDesc(sellerId, pageable);
     }
 
+    public Page<AuctionItem> findBySellerIdAndStatusPaged(Long sellerId, AuctionStatus status, Pageable pageable) {
+        return auctionItemRepository.findBySellerIdAndStatusOrderByCreatedAtDesc(sellerId, status, pageable);
+    }
+
     /**
      * 판매자의 진행 중(ACTIVE) 경매 개수 (탈퇴 시 확인용)
      */

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/port/out/AuctionItemRepository.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/boundedContext/auction/port/out/AuctionItemRepository.java
@@ -33,6 +33,12 @@ public interface AuctionItemRepository extends JpaRepository<AuctionItem, Long> 
         Long sellerId,
         Pageable pageable
     );
+
+    Page<AuctionItem> findBySellerIdAndStatusOrderByCreatedAtDesc(
+        Long sellerId,
+        AuctionStatus status,
+        Pageable pageable
+    );
     
     List<AuctionItem> findByAuctionEndTimeBeforeAndStatus(
         LocalDateTime endTime, 

--- a/fourtune/auction-service/src/main/java/com/fourtune/auction/config/AuctionSecurityRoute.java
+++ b/fourtune/auction-service/src/main/java/com/fourtune/auction/config/AuctionSecurityRoute.java
@@ -12,6 +12,8 @@ public class AuctionSecurityRoute implements SecurityRouteCustomizer {
     @Override
     public void customize(
             AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth) {
+        // 내 경매 목록 조회는 로그인 필수 (permitAll 보다 먼저 선언해야 우선 적용)
+        auth.requestMatchers(HttpMethod.GET, "/api/v1/auctions/me").authenticated();
         // GET 조회만 비로그인 허용 (POST/PUT/DELETE는 인증 필요)
         auth.requestMatchers(HttpMethod.GET, "/api/v1/auctions", "/api/v1/auctions/*").permitAll();
         auth.requestMatchers("/api/v1/search/**").permitAll();


### PR DESCRIPTION
## 📌 개요
'내 경매 관리' 페이지에서 모든 경매가 노출되는 문제를 해결하기 위해 로그인한 판매자의 경매만 반환하는 전용 API를 추가

## 👩‍💻 작업 사항
- [x] `GET /api/v1/auctions/me` 전용 엔드포인트 추가 (인증 필수, 선택적 `status` 필터 지원)
- [x] `AuctionItemRepository` - `findBySellerIdAndStatusOrderByCreatedAtDesc` 메서드 추가
- [x] `AuctionSupport` - `findBySellerIdAndStatusPaged` 메서드 추가
- [x] `AuctionQueryUseCase` - `getSellerAuctions`에 `status` 파라미터 추가 (null이면 전체 조회)
- [x] `AuctionFacade` - `getMyAuctions(sellerId, status, pageable)` 메서드 추가
- [x] `AuctionSecurityRoute` - `/api/v1/auctions/me`를 `authenticated()`로 명시적 인증 요구 설정

## ✅ 테스트 결과
- 테스트가 완료되었음을 확인할 수 있는 스크린샷이나 로그를 첨부해주세요.

## 🔗 관련 이슈
- close #
