### PR TITLE
fix: S3 이미지 URL 생성 오류 및 운영 환경 S3_PUBLIC_URL 누락 (#416)

### DIFF
--- a/fourtune/common/s3/src/main/java/com/fourtune/s3/service/S3Service.java
+++ b/fourtune/common/s3/src/main/java/com/fourtune/s3/service/S3Service.java
@@ -60,7 +60,7 @@ public class S3Service {
 
             s3Client.putObject(putRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
 
-            String fileUrl = publicUrl + "/" + bucket + "/" + key;
+            String fileUrl = publicUrl + "/" + key;
             log.info("파일 업로드 완료: {}", fileUrl);
             return fileUrl;
 
@@ -91,7 +91,7 @@ public class S3Service {
         String presignedUrl = presignedRequest.url().toString();
 
         log.info("Presigned PUT URL generated: {}", presignedUrl);
-        return new S3PresignedUrlResponse(presignedUrl, fileName);
+        return new S3PresignedUrlResponse(presignedUrl, publicUrl + "/" + fileName);
     }
 
     /**

--- a/fourtune/common/s3/src/test/java/com/fourtune/s3/service/S3ServiceTest.java
+++ b/fourtune/common/s3/src/test/java/com/fourtune/s3/service/S3ServiceTest.java
@@ -36,6 +36,7 @@ class S3ServiceTest {
         // @Value 주입 시뮬레이션
         ReflectionTestUtils.setField(s3Service, "bucket", "test-bucket");
         ReflectionTestUtils.setField(s3Service, "pathPrefix", "test/local/tester");
+        ReflectionTestUtils.setField(s3Service, "publicUrl", "https://test-bucket.s3.amazonaws.com");
     }
 
     @Test
@@ -88,10 +89,10 @@ class S3ServiceTest {
         S3PresignedUrlResponse response = s3Service.generatePresignedUrl(directory, fileName, contentType);
 
         // then
-        // [검증] 경로에 슬래시가 두 번 연속되지 않고, pathPrefix 바로 뒤에 파일명이 오는지 확인 (UUID 포함)
-        // 예: test/local/tester/[UUID].jpg
-        assertThat(response.imageUrl()).startsWith("test/local/tester/");
-        assertThat(response.imageUrl()).doesNotContain("//");
+        // [검증] publicUrl + "/" + key 형태의 완전한 URL이 반환되는지 확인
+        // 예: https://test-bucket.s3.amazonaws.com/test/local/tester/[UUID].jpg
+        assertThat(response.imageUrl()).startsWith("https://test-bucket.s3.amazonaws.com/");
+        assertThat(response.imageUrl()).contains("test/local/tester/");
 
         System.out.println("Generated Key: " + response.imageUrl());
     }

--- a/fourtune/docker-compose.prod.yml
+++ b/fourtune/docker-compose.prod.yml
@@ -159,6 +159,7 @@ services:
       - AWS_SECRET_KEY=${AWS_SECRET_KEY}
       - AWS_REGION=${AWS_REGION}
       - AWS_S3_BUCKET=${AWS_S3_BUCKET}
+      - S3_PUBLIC_URL=https://${AWS_S3_BUCKET}.s3.${AWS_REGION:-ap-northeast-2}.amazonaws.com
       - S3_USER_ID=prod
       - TOSS_SECRET_KEY=${TOSS_SECRET_KEY}
       - OAUTH_BACKEND_URI

--- a/fourtune/docker-compose.yml
+++ b/fourtune/docker-compose.yml
@@ -259,7 +259,7 @@ services:
       - AWS_S3_BUCKET=auction-local
       - S3_PATH_PREFIX=local
       - S3_ENDPOINT_URL=http://minio:9000
-      - S3_PUBLIC_URL=http://localhost:9000
+      - S3_PUBLIC_URL=http://localhost:9000/auction-local
       - SPRING_AUTOCONFIGURE_EXCLUDE=io.awspring.cloud.autoconfigure.s3.S3AutoConfiguration
       - FIREBASE_ENABLED=false
       - SPRING_JPA_HIBERNATE_DDL_AUTO=update

--- a/fourtune/fourtune-api/src/main/resources/application.yml
+++ b/fourtune/fourtune-api/src/main/resources/application.yml
@@ -148,7 +148,7 @@ spring:
         bucket: ${AWS_S3_BUCKET}
         path-prefix: "local/${S3_USER_ID}"
         endpoint: ${S3_ENDPOINT_URL:http://minio:9000}
-        public-url: ${S3_PUBLIC_URL:http://localhost:9000}
+        public-url: ${S3_PUBLIC_URL:http://localhost:9000/auction-local}
 
 feature:
   kafka:


### PR DESCRIPTION
## Summary

- `S3Service.generatePresignedUrl()`: `imageUrl`이 S3 key(상대경로)만 반환되던 버그 수정 → `publicUrl + "/" + fileName` 완전한 URL 반환
- `S3Service.uploadFile()`: AWS S3 virtual-hosted URL에서 버킷명이 이중으로 포함되던 버그 수정 → `publicUrl + "/" + key`로 변경
- `docker-compose.prod.yml`: `app` 서비스에 `S3_PUBLIC_URL` 환경변수 누락으로 이미지 URL이 빈 문자열로 시작되던 문제 수정
- `docker-compose.yml` / `application.yml`: 로컬 MinIO `S3_PUBLIC_URL` 기본값에 버킷명 포함하도록 코드 변경에 맞게 통일

## Test plan

- [ ] 운영 서버 재배포 후 경매 이미지 업로드 및 조회 정상 확인
- [ ] Presigned URL 발급 API (`GET /api/v1/images/presigned-url`) 응답의 `imageUrl` 필드가 완전한 URL인지 확인
- [ ] 로컬 환경에서 MinIO 이미지 업로드 및 조회 정상 확인

Closes #416

🤖 Generated with [Claude Code](https://claude.com/claude-code)