### PR TITLE
feat: Nori 분석기 도입을 통한 한국어 검색 품질 개선

### DIFF
--- a/fourtune/Dockerfile.elasticsearch
+++ b/fourtune/Dockerfile.elasticsearch
@@ -1,0 +1,2 @@
+FROM docker.elastic.co/elasticsearch/elasticsearch:9.2.3
+RUN bin/elasticsearch-plugin install analysis-nori

--- a/fourtune/docker-compose.dev.yml
+++ b/fourtune/docker-compose.dev.yml
@@ -50,7 +50,9 @@ services:
 
   # Elasticsearch
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.2.3
+    build:
+      context: .
+      dockerfile: Dockerfile.elasticsearch
     container_name: fourtune-elasticsearch-dev
     environment:
       - discovery.type=single-node

--- a/fourtune/docker-compose.prod.yml
+++ b/fourtune/docker-compose.prod.yml
@@ -65,7 +65,9 @@ services:
 
   # Elasticsearch
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.2.3
+    build:
+      context: .
+      dockerfile: Dockerfile.elasticsearch
     container_name: fourtune-elasticsearch-prod
     environment:
       - discovery.type=single-node

--- a/fourtune/docker-compose.yml
+++ b/fourtune/docker-compose.yml
@@ -44,7 +44,9 @@ services:
 
   # Elasticsearch
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:9.2.3
+    build:
+      context: .
+      dockerfile: Dockerfile.elasticsearch
     container_name: fourtune-elasticsearch
     environment:
       - discovery.type=single-node

--- a/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/document/SearchAuctionItemDocument.java
+++ b/fourtune/fourtune-api/src/main/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/document/SearchAuctionItemDocument.java
@@ -12,16 +12,16 @@ import java.time.ZonedDateTime;
 @AllArgsConstructor
 @Builder
 @Document(indexName = "auction_items")
-// @Setting(settingPath = "...")
+@Setting(settingPath = "elasticsearch/auction-items-settings.json")
 public class SearchAuctionItemDocument {
 
     @Id
     private Long auctionItemId;
 
-    @Field(type = FieldType.Text, analyzer = "standard")
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer", searchAnalyzer = "nori_analyzer")
     private String title;
 
-    @Field(type = FieldType.Text, analyzer = "standard")
+    @Field(type = FieldType.Text, analyzer = "nori_analyzer", searchAnalyzer = "nori_analyzer")
     private String description;
 
     @Field(type = FieldType.Keyword)

--- a/fourtune/fourtune-api/src/main/resources/elasticsearch/auction-items-settings.json
+++ b/fourtune/fourtune-api/src/main/resources/elasticsearch/auction-items-settings.json
@@ -1,0 +1,21 @@
+{
+  "analysis": {
+    "tokenizer": {
+      "nori_mixed": {
+        "type": "nori_tokenizer",
+        "decompound_mode": "mixed"
+      }
+    },
+    "analyzer": {
+      "nori_analyzer": {
+        "type": "custom",
+        "tokenizer": "nori_mixed",
+        "filter": [
+          "nori_readingform",
+          "nori_part_of_speech",
+          "lowercase"
+        ]
+      }
+    }
+  }
+}

--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/FourtuneApplicationTests.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/FourtuneApplicationTests.java
@@ -3,13 +3,24 @@ package com.fourtune.auction;
 import com.fourtune.api.infrastructure.kafka.notification.NotificationKafkaProducer;
 import com.fourtune.api.infrastructure.kafka.search.SearchKafkaProducer;
 import com.fourtune.api.infrastructure.kafka.watchList.WatchListKafkaProducer;
+import com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.ElasticsearchTestContainer;
 import com.google.firebase.messaging.FirebaseMessaging;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
 @SpringBootTest
 class FourtuneApplicationTests {
+
+	private static final ElasticsearchContainer elasticsearchContainer = ElasticsearchTestContainer.getInstance();
+
+	@DynamicPropertySource
+	static void setProperties(DynamicPropertyRegistry registry) {
+		registry.add("spring.elasticsearch.uris", elasticsearchContainer::getHttpHostAddress);
+	}
 
 	@MockitoBean
 	private FirebaseMessaging firebaseMessaging;

--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/ElasticsearchAuctionItemSearchEngineIntegrationTest.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/ElasticsearchAuctionItemSearchEngineIntegrationTest.java
@@ -3,13 +3,12 @@ package com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch;
 import com.fourtune.api.infrastructure.kafka.notification.NotificationKafkaProducer;
 import com.fourtune.api.infrastructure.kafka.search.SearchKafkaProducer;
 import com.fourtune.api.infrastructure.kafka.watchList.WatchListKafkaProducer;
+import com.fourtune.auction.boundedContext.search.adapter.in.event.AuctionItemIndexEventListener;
 import com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.document.SearchAuctionItemDocument;
 import com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.repository.SearchAuctionItemCrudRepository;
-import com.fourtune.auction.boundedContext.search.domain.SearchAuctionItemView;
-import com.fourtune.auction.boundedContext.search.domain.SearchCondition;
-import com.fourtune.auction.boundedContext.search.domain.SearchPriceRange;
-import com.fourtune.auction.boundedContext.search.domain.SearchResultPage;
+import com.fourtune.auction.boundedContext.search.domain.*;
 import com.fourtune.auction.boundedContext.search.domain.constant.SearchSort;
+import com.google.firebase.messaging.FirebaseMessaging;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,11 +20,8 @@ import org.springframework.data.elasticsearch.core.IndexOperations;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import java.math.BigDecimal;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Set;
 
@@ -33,21 +29,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * ElasticSearch 검색 엔진 통합 테스트
- * - Testcontainers를 사용하여 실제 ElasticSearch 환경에서 테스트를 수행
- * - 검색 기능(키워드, 필터, 정렬, 페이징)이 정상 작동하는지 검증할 것
+ * - 싱글턴 ElasticsearchTestContainer를 사용 (Nori 플러그인 포함)
+ * - elasticsearch/Dockerfile을 재사용하므로 ES 버전/플러그인 변경 시 Dockerfile만 수정하면 됨
  */
 @SpringBootTest
-@Testcontainers
 @DisplayName("ElasticSearch 검색 엔진 통합 테스트")
 class ElasticsearchAuctionItemSearchEngineIntegrationTest {
 
-    @Container
-    static ElasticsearchContainer elasticsearch = new ElasticsearchContainer(
-            "docker.elastic.co/elasticsearch/elasticsearch:9.2.3")
-            .withEnv("xpack.security.enabled", "false")
-            .withEnv("discovery.type", "single-node")
-            .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
-            .withStartupTimeout(Duration.ofMinutes(5)); // 타임아웃 시간을 5분으로 연장
+    static ElasticsearchContainer elasticsearch = ElasticsearchTestContainer.getInstance();
 
     @DynamicPropertySource
     static void setProperties(DynamicPropertyRegistry registry) {
@@ -55,13 +44,10 @@ class ElasticsearchAuctionItemSearchEngineIntegrationTest {
     }
 
     @MockitoBean
-    private com.google.firebase.messaging.FirebaseMessaging firebaseMessaging;
+    private FirebaseMessaging firebaseMessaging;
 
     @MockitoBean
-    private com.fourtune.auction.boundedContext.search.adapter.in.event.AuctionItemIndexEventListener auctionItemIndexEventListener;
-
-    @MockitoBean
-    private com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.ElasticsearchAuctionItemIndexingHandler elasticsearchAuctionItemIndexingHandler;
+    private AuctionItemIndexEventListener auctionItemIndexEventListener;
 
     @MockitoBean
     private WatchListKafkaProducer watchListKafkaProducer;
@@ -268,7 +254,8 @@ class ElasticsearchAuctionItemSearchEngineIntegrationTest {
         SearchResultPage<SearchAuctionItemView> result = searchEngine.search(condition);
 
         // then
-        result.items().forEach(item -> System.out.println("Result Item: " + item.title() + ", View: " + item.viewCount()));
+        result.items()
+                .forEach(item -> System.out.println("Result Item: " + item.title() + ", View: " + item.viewCount()));
 
         assertThat(result.items()).hasSize(3);
         assertThat(result.items().get(0).title()).isEqualTo("인기 많음");

--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/ElasticsearchAuctionItemSearchEngineIntegrationTest.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/ElasticsearchAuctionItemSearchEngineIntegrationTest.java
@@ -134,6 +134,34 @@ class ElasticsearchAuctionItemSearchEngineIntegrationTest {
     }
 
     @Test
+    @DisplayName("Nori 분석기: 복합어 및 조사가 포함된 한국어 검색이 정상 작동해야 한다")
+    void search_ByNoriAnalyzer_ShouldHandleKoreanMorphology() {
+        // given
+        // 1. 복합어 (붙여쓰기)
+        saveTestDocument("맥북프로", "최신형 노트북", "ELECTRONICS", "ACTIVE", 2000000, 0L);
+        // 2. 조사 포함된 데이터
+        saveTestDocument("아이폰이 예뻐요", "스마트폰", "ELECTRONICS", "ACTIVE", 1200000, 0L);
+        // 3. 복합어 (삼성전자)
+        saveTestDocument("삼성전자 갤럭시북", "노트북", "ELECTRONICS", "ACTIVE", 1500000, 0L);
+        refreshIndex();
+
+        // Case 1: 복합어 분해 검색 ("맥북"으로 "맥북프로" 찾기)
+        SearchCondition cond1 = new SearchCondition("맥북", null, null, null, SearchSort.LATEST, 1);
+        SearchResultPage<SearchAuctionItemView> res1 = searchEngine.search(cond1);
+        assertThat(res1.items()).extracting(SearchAuctionItemView::title).contains("맥북프로");
+
+        // Case 2: 조사 제거 검색 ("아이폰"으로 "아이폰이 예뻐요" 찾기)
+        SearchCondition cond2 = new SearchCondition("아이폰", null, null, null, SearchSort.LATEST, 1);
+        SearchResultPage<SearchAuctionItemView> res2 = searchEngine.search(cond2);
+        assertThat(res2.items()).extracting(SearchAuctionItemView::title).contains("아이폰이 예뻐요");
+
+        // Case 3: 복합어 내부 키워드 검색 ("삼성"으로 "삼성전자 갤럭시북" 찾기)
+        SearchCondition cond3 = new SearchCondition("삼성", null, null, null, SearchSort.LATEST, 1);
+        SearchResultPage<SearchAuctionItemView> res3 = searchEngine.search(cond3);
+        assertThat(res3.items()).extracting(SearchAuctionItemView::title).contains("삼성전자 갤럭시북");
+    }
+
+    @Test
     @DisplayName("특정 카테고리에 속한 상품만 필터링되어야 한다")
     void search_ByCategory_ShouldReturnOnlyMatchingCategory() {
         // given

--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/ElasticsearchTestContainer.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/adapter/out/elasticsearch/ElasticsearchTestContainer.java
@@ -1,0 +1,49 @@
+package com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch;
+
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+/**
+ * Elasticsearch Testcontainer 싱글턴.
+ * Nori 플러그인이 포함된 커스텀 ES 이미지를 빌드하여 사용합니다.
+ * ES 버전 변경 시 {@link #ES_VERSION} 상수와 {@code Dockerfile.elasticsearch}를 함께
+ * 수정하세요.
+ */
+public final class ElasticsearchTestContainer {
+
+    // Elasticsearch 버전 — Dockerfile.elasticsearch 의 FROM과 반드시 동일하게 유지할 것.
+    static final String ES_VERSION = "9.2.3";
+
+    private static final ElasticsearchContainer CONTAINER = createContainer();
+
+    private ElasticsearchTestContainer() {
+        // 인스턴스 생성 방지
+    }
+
+    @SuppressWarnings("resource") // 싱글턴 — JVM 종료 시까지 유지
+    private static ElasticsearchContainer createContainer() {
+        ImageFromDockerfile image = new ImageFromDockerfile("fourtune-es-test", false)
+                .withDockerfileFromBuilder(
+                        builder -> builder.from("docker.elastic.co/elasticsearch/elasticsearch:" + ES_VERSION)
+                                .run("bin/elasticsearch-plugin install analysis-nori")
+                                .build());
+
+        ElasticsearchContainer container = new ElasticsearchContainer(
+                DockerImageName.parse(image.get())
+                        .asCompatibleSubstituteFor("docker.elastic.co/elasticsearch/elasticsearch"))
+                .withEnv("xpack.security.enabled", "false")
+                .withEnv("discovery.type", "single-node")
+                .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
+                .withStartupTimeout(Duration.ofMinutes(5));
+
+        container.start();
+        return container;
+    }
+
+    public static ElasticsearchContainer getInstance() {
+        return CONTAINER;
+    }
+}

--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/application/service/SearchFacadeIntegrationTest.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/application/service/SearchFacadeIntegrationTest.java
@@ -2,19 +2,16 @@ package com.fourtune.auction.boundedContext.search.application.service;
 
 import com.fourtune.api.infrastructure.kafka.notification.NotificationKafkaProducer;
 import com.fourtune.api.infrastructure.kafka.watchList.WatchListKafkaProducer;
-import com.fourtune.auction.boundedContext.notification.adapter.in.kafka.NotificationUserKafkaListener;
 import com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.document.SearchAuctionItemDocument;
+import com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.ElasticsearchTestContainer;
 import com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.repository.SearchAuctionItemCrudRepository;
 import com.fourtune.auction.boundedContext.search.domain.SearchAuctionItemView;
 import com.fourtune.auction.boundedContext.search.domain.SearchLog;
 import com.fourtune.auction.boundedContext.search.domain.SearchCondition;
 import com.fourtune.auction.boundedContext.search.domain.constant.SearchSort;
 import com.fourtune.auction.boundedContext.search.domain.SearchResultPage;
-import com.fourtune.auction.boundedContext.settlement.adapter.in.kafka.SettlementUserKafkaListener;
-import com.fourtune.auction.boundedContext.watchList.adapter.in.kafka.WatchListUserKafkaListener;
 import com.fourtune.api.infrastructure.kafka.search.SearchKafkaProducer;
 import com.fourtune.shared.search.event.SearchAuctionItemEvent;
-import com.google.firebase.messaging.FirebaseMessaging;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +30,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.utility.DockerImageName;
 
 import java.math.BigDecimal;
-import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -49,14 +45,8 @@ import org.mockito.ArgumentCaptor;
 @DisplayName("SearchFacade 통합 테스트 (ES + Redis)")
 class SearchFacadeIntegrationTest {
 
-    // 1. Elasticsearch Container
-    @Container
-    static ElasticsearchContainer elasticsearch = new ElasticsearchContainer(
-            "docker.elastic.co/elasticsearch/elasticsearch:9.2.3") // 프로젝트 버전과 일치 확인 필요 (기존 테스트 참고함)
-            .withEnv("xpack.security.enabled", "false")
-            .withEnv("discovery.type", "single-node")
-            .withEnv("ES_JAVA_OPTS", "-Xms512m -Xmx512m")
-            .withStartupTimeout(Duration.ofMinutes(5));
+    // 1. Elasticsearch Container (Nori 포함 싱글턴 사용)
+    static ElasticsearchContainer elasticsearch = ElasticsearchTestContainer.getInstance();
 
     // 2. Redis Container
     @Container
@@ -69,10 +59,6 @@ class SearchFacadeIntegrationTest {
         registry.add("spring.data.redis.host", redis::getHost);
         registry.add("spring.data.redis.port", redis::getFirstMappedPort);
     }
-
-    // Mock External Dependencies to prevent context load failure
-    @MockitoBean
-    private com.google.firebase.messaging.FirebaseMessaging firebaseMessaging;
 
     @MockitoBean
     private com.fourtune.auction.boundedContext.search.adapter.in.event.AuctionItemIndexEventListener auctionItemIndexEventListener;

--- a/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/application/service/SearchFacadeIntegrationTest.java
+++ b/fourtune/fourtune-api/src/test/java/com/fourtune/auction/boundedContext/search/application/service/SearchFacadeIntegrationTest.java
@@ -2,6 +2,7 @@ package com.fourtune.auction.boundedContext.search.application.service;
 
 import com.fourtune.api.infrastructure.kafka.notification.NotificationKafkaProducer;
 import com.fourtune.api.infrastructure.kafka.watchList.WatchListKafkaProducer;
+import com.fourtune.auction.boundedContext.search.adapter.in.event.AuctionItemIndexEventListener;
 import com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.document.SearchAuctionItemDocument;
 import com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.ElasticsearchTestContainer;
 import com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.repository.SearchAuctionItemCrudRepository;
@@ -12,6 +13,7 @@ import com.fourtune.auction.boundedContext.search.domain.constant.SearchSort;
 import com.fourtune.auction.boundedContext.search.domain.SearchResultPage;
 import com.fourtune.api.infrastructure.kafka.search.SearchKafkaProducer;
 import com.fourtune.shared.search.event.SearchAuctionItemEvent;
+import com.google.firebase.messaging.FirebaseMessaging;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -61,7 +63,10 @@ class SearchFacadeIntegrationTest {
     }
 
     @MockitoBean
-    private com.fourtune.auction.boundedContext.search.adapter.in.event.AuctionItemIndexEventListener auctionItemIndexEventListener;
+    private FirebaseMessaging firebaseMessaging;
+
+    @MockitoBean
+    private AuctionItemIndexEventListener auctionItemIndexEventListener;
 
     @MockitoBean
     private com.fourtune.auction.boundedContext.search.adapter.out.elasticsearch.ElasticsearchAuctionItemIndexingHandler elasticsearchAuctionItemIndexingHandler;


### PR DESCRIPTION
## 📌 개요
- 기존의 standard 분석기는 한국어 특유의 조사 처리나 복합어 분해가 불가능하여 검색 결과가 누락되는 한계가 있었습니다. 이를 해결하기 위해 Elasticsearch 전용 한국어 분석기인 **Nori**를 도입하고, Docker 및 테스트 환경을 이에 맞춰 리팩토링하였습니다.

## 👩‍💻 작업 사항
1. 인프라 및 Docker 설정 (인프라 Single Source of Truth 구축)
- [x] 커스텀 ES 이미지 생성: 기존 사용하던 버전인 Elasticsearch 9.2.3 이미지에 Nori 플러그인을 설치하는 Dockerfile.elasticsearch 를 프로젝트 루트에 추가하였습니다. 
- [x] Docker Compose 업데이트: 로컬(local), 개발(dev), 운영(prod) 환경의 모든 Docker Compose 파일이 커스텀 빌드된 ES 이미지를 사용하도록 수정하였습니다. 
- [x] 유지보수성 강화: MSA 전환을 고려하여 앱 빌드용 Dockerfile과 인프라용 Dockerfile을 명확히 분리하였습니다.

2. Elasticsearch 인덱스 및 매핑 설정
- [x] 분석기 정의 (auction-items-settings.json
): mixed 모드의 토크나이저를 사용하여 복합어(예: "삼성전자")를 원형과 개별 단어로 모두 분해해 인덱싱합니다. 
- [x] 한국어 품사 필터(nori_part_of_speech)를 적용하여 의미 없는 조사를 제거하고 검색 정확도를 높였습니다.

3. 테스트 환경 리팩토링 및 검증
- [x] 싱글턴 테스트 컨테이너 (ElasticsearchTestContainer): 테스트 실행 시마다 Nori 환경이 포함된 컨테이너를 동적으로 빌드하는 싱글턴 객체를 구현하였습니다. 
- [x] ES_VERSION 상수를 통해 버전 관리를 일원화하고, 외부 파일 경로 의존성 문제를 해결했습니다.
- [x] 한국어 형태소 분석 검증: 테스트 케이스를 추가하여 복합어 분해, 조사 제거, 부분 일치 검색이 의도대로 동작함을 정량적 검증 완료했였습니다.

## ✅ 테스트 결과
- 통합 테스트: 총 11개 테스트 케이스 모두 통과 (BUILD SUCCESSFUL)
- 수동 검증: _analyze API를 통해 "맥북프로", "아이폰이" 등의 키워드가 형태소 단위로 정상 분해됨을 확인했습니다.

## 🔗 관련 이슈
- close #421
