### PR TITLE
fix: POSTGRES_DB 자동 생성 제거로 fourtune_db 중복 생성 오류 해결 및 관리 일관성 확보

### DIFF
--- a/fourtune/docker-compose.dev.yml
+++ b/fourtune/docker-compose.dev.yml
@@ -9,7 +9,6 @@ services:
     image: postgres:16-alpine
     container_name: fourtune-postgres-dev
     environment:
-      POSTGRES_DB: ${DB_NAME:-fourtune_db}
       POSTGRES_USER: ${DB_USERNAME:-fourtune_user}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     ports:
@@ -24,7 +23,7 @@ services:
       test:
         [
           "CMD-SHELL",
-          "pg_isready -U ${DB_USERNAME:-fourtune_user} -d ${DB_NAME:-fourtune_db}",
+          "pg_isready -U ${DB_USERNAME:-fourtune_user} -d postgres",
         ]
       interval: 10s
       timeout: 5s

--- a/fourtune/docker-compose.prod.yml
+++ b/fourtune/docker-compose.prod.yml
@@ -8,7 +8,6 @@ services:
     ports:
       - "127.0.0.1:5432:5432"
     environment:
-      POSTGRES_DB: ${DB_NAME:-fourtune_db}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
     volumes:
@@ -27,7 +26,7 @@ services:
           memory: 512M
     healthcheck:
       test:
-        ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d ${DB_NAME:-fourtune_db}"]
+        ["CMD-SHELL", "pg_isready -U ${DB_USERNAME} -d postgres"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/fourtune/docker-compose.yml
+++ b/fourtune/docker-compose.yml
@@ -8,7 +8,6 @@ services:
     image: postgres:16-alpine
     container_name: fourtune-postgres
     environment:
-      POSTGRES_DB: fourtune_db
       POSTGRES_USER: fourtune_user
       POSTGRES_PASSWORD: fourtune
     ports:
@@ -20,7 +19,7 @@ services:
     networks:
       - fourtune-network
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U fourtune_user -d fourtune_db"]
+      test: ["CMD-SHELL", "pg_isready -U fourtune_user -d postgres"]
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## 📌 개요
- Docker Compose의 POSTGRES_DB 환경 변수를 이용한 자동 생성 기능과 init-db 초기화 스크립트에서의 CREATE DATABASE 명령이 충돌하여 발생하는 database "fourtune_db already exists" 오류를 해결했습니다. MSA 구조 확장에 대비하여 모든 서비스의 데이터베이스 생성 로직을 init-db 스크립트 방식으로 일원화했습니다.

## 👩‍💻 작업 사항
- [x] Docker Compose 수정 (로컬/개발/운영)
  - POSTGRES_DB: fourtune_db 환경 변수 제거 (자동 생성 중단)
  - PostgreSQL 컨테이너의 healthcheck 대상을 기본 데이터베이스인 postgres로 변경하여 초기화 도중에도 안정적인 상태 체크 보장
- [x] 데이터베이스 관리 일관성 확보
  - fourtune_db, auction, recommendation, payment_db 등 모든 데이터베이스 생성을 init-db/*.sh 스크립트가 전담하도록 역할 분리하는 것은 수정없이 그대로 유지하는 방향으로 작업

## ✅ 테스트 결과
`docker-compose up -d --build` 명령어 실행 시, postgres가 터지지 않고 모든 컨테이너가 한번에 정상적으로 빌드되는 것을 확인할 수 있음
<img width="506" height="522" alt="image" src="https://github.com/user-attachments/assets/cd8adba0-3dac-40bf-9e7d-9448a104b05b" />

## 🔗 관련 이슈
- close #423
