### PR TITLE
refactor: RecommendationScheduler에서 Redis KEYS *를 SCAN으로 대체하여 성능 및 안정성 보완

### DIFF
--- a/fourtune/recommendation-service/src/main/java/com/fourtune/recommendation/application/service/RecommendationScheduler.java
+++ b/fourtune/recommendation-service/src/main/java/com/fourtune/recommendation/application/service/RecommendationScheduler.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -38,15 +40,18 @@ public class RecommendationScheduler {
     private long cacheTtlSeconds;
 
     /**
-     * 활성 사용자들의 추천 결과를 배치로 갱신합니다.
-     * 프로파일이 존재하는 사용자(metrics:user:*)를 대상으로 합니다.
+     * 활성 사용자들의 추천 결과를 배치로 갱신
+     * 프로파일이 존재하는 사용자(metrics:user:*)를 대상으로 함
+     *
+     * SCAN 커맨드를 사용하여 Redis 블로킹을 방지
+     * (KEYS * 명령은 O(N)으로 싱글 스레드인 Redis를 블로킹하여 전체 서비스에 영향을 줄 수 있음)
      */
     @Scheduled(fixedRateString = "${recommendation.schedule.interval}")
     public void refreshRecommendations() {
         log.info("[REC][SCHEDULER] 추천 배치 갱신 시작");
 
-        Set<String> userKeys = redisTemplate.keys(RecommendationConstants.USER_METRICS_KEY_PREFIX + "*");
-        if (userKeys == null || userKeys.isEmpty()) {
+        Set<String> userKeys = scanUserKeys();
+        if (userKeys.isEmpty()) {
             log.info("[REC][SCHEDULER] 활성 사용자 없음, 스킵");
             return;
         }
@@ -94,6 +99,24 @@ public class RecommendationScheduler {
         }
 
         log.info("[REC][SCHEDULER] 추천 배치 완료: 성공={}, 실패={}, 전체={}", success, fail, userKeys.size());
+    }
+
+    /**
+     * Redis SCAN 커맨드로 사용자 프로파일 키 조회
+     */
+    private Set<String> scanUserKeys() {
+        Set<String> keys = new HashSet<>();
+        ScanOptions options = ScanOptions.scanOptions()
+                .match(RecommendationConstants.USER_METRICS_KEY_PREFIX + "*")
+                .count(100)
+                .build();
+
+        try (Cursor<String> cursor = redisTemplate.scan(options)) {
+            while (cursor.hasNext()) {
+                keys.add(cursor.next());
+            }
+        }
+        return keys;
     }
 
     private Long extractUserId(String key) {

--- a/fourtune/recommendation-service/src/test/java/com/fourtune/recommendation/application/service/RecommendationSchedulerTest.java
+++ b/fourtune/recommendation-service/src/test/java/com/fourtune/recommendation/application/service/RecommendationSchedulerTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 
@@ -49,7 +51,7 @@ class RecommendationSchedulerTest {
     @Test
     @DisplayName("활성 사용자가 없으면 스킵")
     void refreshRecommendations_noActiveUsers_skips() {
-        when(redisTemplate.keys("metrics:user:*")).thenReturn(Collections.emptySet());
+        when(redisTemplate.scan(any(ScanOptions.class))).thenReturn(emptyCursor());
 
         scheduler.refreshRecommendations();
 
@@ -60,8 +62,7 @@ class RecommendationSchedulerTest {
     @Test
     @DisplayName("활성 사용자 있으면 Feign → AI → Redis 캐싱 호출")
     void refreshRecommendations_activeUser_generatesAndCaches() {
-        Set<String> keys = Set.of("metrics:user:42");
-        when(redisTemplate.keys("metrics:user:*")).thenReturn(keys);
+        when(redisTemplate.scan(any(ScanOptions.class))).thenReturn(cursorOf("metrics:user:42"));
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
         when(userPreferenceService.getTopCategories(42L, RecommendationConstants.TOP_CATEGORY_LIMIT))
@@ -84,7 +85,7 @@ class RecommendationSchedulerTest {
     @Test
     @DisplayName("프로파일 없는 사용자는 건너뜀")
     void refreshRecommendations_noProfile_skipsUser() {
-        when(redisTemplate.keys("metrics:user:*")).thenReturn(Set.of("metrics:user:99"));
+        when(redisTemplate.scan(any(ScanOptions.class))).thenReturn(cursorOf("metrics:user:99"));
         when(userPreferenceService.getTopCategories(99L, RecommendationConstants.TOP_CATEGORY_LIMIT))
                 .thenReturn(Collections.emptyList());
 
@@ -96,8 +97,8 @@ class RecommendationSchedulerTest {
     @Test
     @DisplayName("개별 사용자 실패해도 다른 사용자는 계속 처리")
     void refreshRecommendations_oneUserFails_continuesOthers() {
-        Set<String> keys = new LinkedHashSet<>(List.of("metrics:user:1", "metrics:user:2"));
-        when(redisTemplate.keys("metrics:user:*")).thenReturn(keys);
+        when(redisTemplate.scan(any(ScanOptions.class)))
+                .thenReturn(cursorOf("metrics:user:1", "metrics:user:2"));
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
         // 사용자 1, 2 모두 카테고리 존재
@@ -121,6 +122,22 @@ class RecommendationSchedulerTest {
     }
 
     // ── 헬퍼 ──
+
+    @SuppressWarnings("unchecked")
+    private Cursor<String> emptyCursor() {
+        Cursor<String> cursor = mock(Cursor.class);
+        when(cursor.hasNext()).thenReturn(false);
+        return cursor;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Cursor<String> cursorOf(String... keys) {
+        Cursor<String> cursor = mock(Cursor.class);
+        Iterator<String> iterator = Arrays.asList(keys).iterator();
+        when(cursor.hasNext()).thenAnswer(inv -> iterator.hasNext());
+        when(cursor.next()).thenAnswer(inv -> iterator.next());
+        return cursor;
+    }
 
     private RecommendedItemResponse createItem(Long id, String title) {
         return new RecommendedItemResponse(id, title, "카테고리", "ACTIVE",

--- a/fourtune/recommendation-service/src/test/java/com/fourtune/recommendation/application/service/RecommendationSchedulerTest.java
+++ b/fourtune/recommendation-service/src/test/java/com/fourtune/recommendation/application/service/RecommendationSchedulerTest.java
@@ -51,7 +51,8 @@ class RecommendationSchedulerTest {
     @Test
     @DisplayName("활성 사용자가 없으면 스킵")
     void refreshRecommendations_noActiveUsers_skips() {
-        when(redisTemplate.scan(any(ScanOptions.class))).thenReturn(emptyCursor());
+        Cursor<String> cursor = emptyCursor();
+        when(redisTemplate.scan(any(ScanOptions.class))).thenReturn(cursor);
 
         scheduler.refreshRecommendations();
 
@@ -62,7 +63,8 @@ class RecommendationSchedulerTest {
     @Test
     @DisplayName("활성 사용자 있으면 Feign → AI → Redis 캐싱 호출")
     void refreshRecommendations_activeUser_generatesAndCaches() {
-        when(redisTemplate.scan(any(ScanOptions.class))).thenReturn(cursorOf("metrics:user:42"));
+        Cursor<String> cursor = cursorOf("metrics:user:42");
+        when(redisTemplate.scan(any(ScanOptions.class))).thenReturn(cursor);
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
         when(userPreferenceService.getTopCategories(42L, RecommendationConstants.TOP_CATEGORY_LIMIT))
@@ -85,7 +87,8 @@ class RecommendationSchedulerTest {
     @Test
     @DisplayName("프로파일 없는 사용자는 건너뜀")
     void refreshRecommendations_noProfile_skipsUser() {
-        when(redisTemplate.scan(any(ScanOptions.class))).thenReturn(cursorOf("metrics:user:99"));
+        Cursor<String> cursor = cursorOf("metrics:user:99");
+        when(redisTemplate.scan(any(ScanOptions.class))).thenReturn(cursor);
         when(userPreferenceService.getTopCategories(99L, RecommendationConstants.TOP_CATEGORY_LIMIT))
                 .thenReturn(Collections.emptyList());
 
@@ -97,28 +100,31 @@ class RecommendationSchedulerTest {
     @Test
     @DisplayName("개별 사용자 실패해도 다른 사용자는 계속 처리")
     void refreshRecommendations_oneUserFails_continuesOthers() {
-        when(redisTemplate.scan(any(ScanOptions.class)))
-                .thenReturn(cursorOf("metrics:user:1", "metrics:user:2"));
+        Cursor<String> cursor = cursorOf("metrics:user:1", "metrics:user:2");
+        when(redisTemplate.scan(any(ScanOptions.class))).thenReturn(cursor);
         when(redisTemplate.opsForValue()).thenReturn(valueOperations);
 
         // 사용자 1, 2 모두 카테고리 존재
         when(userPreferenceService.getTopCategories(anyLong(), eq(RecommendationConstants.TOP_CATEGORY_LIMIT)))
                 .thenReturn(List.of("전자기기"));
 
-        // 첫 번째 호출(사용자 1)은 실패, 두 번째 호출(사용자 2)은 성공
+        // 첫 번째 호출은 실패, 두 번째 호출은 성공
+        // (HashSet 특성상 순서가 비결정적이므로 어떤 사용자가 먼저 처리될지 알 수 없음)
         Map<String, Object> searchResult = new HashMap<>();
         searchResult.put("items", List.of(createItemMap(200L, "패션상품")));
         when(searchClient.searchAuctionItems(any(), any(), any(), any()))
                 .thenThrow(new RuntimeException("fail"))
                 .thenReturn(searchResult);
 
-        when(aiClient.recommend(eq(2L), any(), any()))
+        when(aiClient.recommend(anyLong(), any(), any()))
                 .thenReturn(List.of(createItem(200L, "패션상품")));
 
         scheduler.refreshRecommendations();
 
-        // 사용자 2의 AI 호출이 발생했는지 확인
-        verify(aiClient).recommend(eq(2L), any(), any());
+        // 핵심 검증: 한 명이 실패해도 루프가 중단되지 않고 나머지 사용자를 처리함
+        // searchClient는 2번 호출 (1번 실패 + 1번 성공), aiClient는 성공한 1명에 대해 1번만 호출
+        verify(searchClient, times(2)).searchAuctionItems(any(), any(), any(), any());
+        verify(aiClient, times(1)).recommend(anyLong(), any(), any());
     }
 
     // ── 헬퍼 ──
@@ -126,7 +132,7 @@ class RecommendationSchedulerTest {
     @SuppressWarnings("unchecked")
     private Cursor<String> emptyCursor() {
         Cursor<String> cursor = mock(Cursor.class);
-        when(cursor.hasNext()).thenReturn(false);
+        doReturn(false).when(cursor).hasNext();
         return cursor;
     }
 
@@ -134,8 +140,8 @@ class RecommendationSchedulerTest {
     private Cursor<String> cursorOf(String... keys) {
         Cursor<String> cursor = mock(Cursor.class);
         Iterator<String> iterator = Arrays.asList(keys).iterator();
-        when(cursor.hasNext()).thenAnswer(inv -> iterator.hasNext());
-        when(cursor.next()).thenAnswer(inv -> iterator.next());
+        doAnswer(inv -> iterator.hasNext()).when(cursor).hasNext();
+        doAnswer(inv -> iterator.next()).when(cursor).next();
         return cursor;
     }
 


### PR DESCRIPTION
## 📌 개요
- 추천 서비스의 스케줄링 작업 중 발생하는 Redis 성능 병목 및 블로킹 위험을 해소하기 위해 리팩토링을 진행했습니다.
- 문제: 기존 KEYS * 명령어는 O(N)으로 전체 키 공간을 탐색하며, 실행 중 Redis의 싱글 스레드를 점유하여 다른 서비스(JWT 검증, 캐시 등)를 블로킹할 위험이 있다고 판단됨.
- 해결: Cursor 기반의 SCAN 커맨드를 도입하여 논블로킹 방식으로 안전하게 사용자 프로파일 키를 조회하도록 변경 완료.

## 👩‍💻 작업 사항
- [x] RecommendationScheduler 리팩토링
  - redisTemplate.keys() 호출을 제거 
  - redisTemplate.scan()과 try-with-resources를 활용한 scanUserKeys() 전용 메서드 구현
  - 스캔 시 count로 옵션을 주어 한 번의 반복당 처리량을 조절
- [x] 단위 테스트 코드 업데이트 
  - RecommendationSchedulerTest 에서 scan()호출 및 Cursor 동작을 모킹하도록 수정하여 변경된 로직 검증

## ✅ 테스트 결과
- [x] RecommendationSchedulerTest 내 4개 테스트 케이스 모두 통과 확인 
  - 활성 사용자 검색 및 추천 배치 생성 시나리오 검증
  - 예외 발생 시 전파 및 후속 처리 루프 유지 검증

## 🔗 관련 이슈
- close #428
