### PR TITLE
feature/431

### DIFF
--- a/fourtune/prometheus.yml
+++ b/fourtune/prometheus.yml
@@ -39,3 +39,13 @@ scrape_configs:
         labels:
           application: 'auction-service'
           environment: 'docker'
+
+  # Docker Compose 내부 네트워크: recommendation-service (추천 MSA, 8084)
+  - job_name: 'recommendation-service'
+    metrics_path: '/actuator/prometheus'
+    scrape_interval: 5s
+    static_configs:
+      - targets: ['recommendation-service:8084']
+        labels:
+          application: 'recommendation-service'
+          environment: 'docker'

--- a/fourtune/recommendation-service/src/main/resources/application.yml
+++ b/fourtune/recommendation-service/src/main/resources/application.yml
@@ -73,3 +73,17 @@ springdoc:
   paths-to-exclude:
     - /actuator/**
     - /error
+
+# ─ Actuator & Prometheus 메트릭 수집 설정 ─
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics,prometheus
+  metrics:
+    tags:
+      application: ${spring.application.name}   # Grafana에서 서비스 구분할 때 사용
+  prometheus:
+    metrics:
+      export:
+        enabled: true


### PR DESCRIPTION
## 📌 개요
- 추천 서비스(`recommendation-service`)의 성능 관측성 확보를 위해 Prometheus 메트릭 수집 설정을 추가했습니다.
- 기존에는 `fourtune-api`에만 모니터링이 구성되어 있어, 추천 시스템의 배치 처리 효율이나 리소스 사용량을 정량적으로 파악하기 어려운 상태였습니다.

## 👩‍💻 작업 사항
- **Actuator/Prometheus 엔드포인트 노출**:
    - 추천 서비스의 application.yml에 `management` 설정을 추가하여 `/actuator/prometheus`를 활성화했습니다.
- **마이크로미터 서비스 식별 태그 설정**:
    - `application` 태그에 `${spring.application.name}`을 부여하여 Grafana 대시보드에서 `fourtune-api`와 `recommendation-service(추천 서비스)`를 구분하여 모니터링할 수 있도록 해두었습니다.
- **Prometheus Scrape Target으로 등록**:
    - prometheus.yml 파일에 `recommendation-service` 작업을 추가하여 Docker Compose 환경에서 자동으로 메트릭을 수집할 수 있도록 설정했습니다. (포트: 8084)

## ✅ 테스트 결과
- **엔드포인트 확인**: `http://localhost:9082/actuator/prometheus` 접속 시 JVM 및 애플리케이션 메트릭 데이터가 정상 출력됨을 확인함
- **Prometheus 연동**: `http://localhost:9090/targets` 에서 `recommendation-service`가 `UP` 상태로 정상 등록됨을 확인함
- **Grafana**: JVM Micrometer 대시보드(ID 11378) 등을 통해 추천 서비스의 CPU, Memory, Latency 지표가 실시간으로 수집되는 것을 확인함

## 🔗 관련 이슈
- close #431
